### PR TITLE
Update `ESLint` to `v4`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
         "dot-notation": "error",
         "eol-last": "error",
         "eqeqeq": "error",
+        "for-direction": "error",
         "func-call-spacing": "error",
         "func-names": "off",
         "func-style": ["error", "expression"],
@@ -67,17 +68,15 @@
         "keyword-spacing": "error",
         "linebreak-style": "off",
         "lines-around-comment": "off",
-        "lines-around-directive": "error",
         "max-len": "off",
         "max-nested-callbacks": ["error", 5],
         "max-statements-per-line": "error",
         "new-cap": "error",
         "new-parens": "error",
-        "newline-after-var": "error",
-        "newline-before-return": "error",
         "newline-per-chained-call": "error",
         "no-alert": "error",
         "no-array-constructor": "error",
+        "no-buffer-constructor": "error",
         "no-caller": "error",
         "no-case-declarations": "error",
         "no-catch-shadow": "error",
@@ -212,6 +211,15 @@
         "one-var": "off",
         "operator-assignment": ["error", "always"],
         "operator-linebreak": ["error", "after"],
+        "padding-line-between-statements": [ "error",
+            { "blankLine": "always", "prev": "*", "next": "return" },
+
+            { "blankLine": "always", "prev": ["const", "let", "var"], "next": "*"},
+            { "blankLine": "any", "prev": ["const", "let", "var"], "next": ["const", "let", "var"]},
+
+            { "blankLine": "always", "prev": "directive", "next": "*" },
+            { "blankLine": "any", "prev": "directive", "next": "directive" }
+        ],
         "prefer-arrow-callback": "error",
         "prefer-const": "error",
         "prefer-numeric-literals": "error",
@@ -227,6 +235,7 @@
             "after": true
         }],
         "semi": ["error", "always"],
+        "semi-style": ["error", "last"],
         "sort-keys": "error",
         "sort-vars": "off",
         "spaced-comment": ["error", "always"],
@@ -236,6 +245,7 @@
             "nonwords": false
         }],
         "strict": ["error", "never"], // We are using alwaysStrict=true as a compiler option of TS
+        "switch-colon-spacing": ["error", { "after" : true, "before" : false }],
         "template-curly-spacing": "error",
         "use-isnan": "error",
         "unicode-bom": "error",

--- a/docs/developer-guide/rules/how-to-test-rules.md
+++ b/docs/developer-guide/rules/how-to-test-rules.md
@@ -46,10 +46,10 @@ The signature of `ruleRunner.testRule` is:
 <!-- eslint-disable no-unused-vars -->
 
 ```js
-  const serverConfig = {
-      '/': 'some HTML here',
-      'site.webmanifest': 'other content'
-  };
+const serverConfig = {
+    '/': 'some HTML here',
+    'site.webmanifest': 'other content'
+};
 ```
 
 You can even specify the headers and status code for the response for

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "chrome-remote-interface": "^0.23.2",
     "content-type": "^1.0.2",
     "debug": "^2.6.8",
-    "eslint": "^3.19.0",
+    "eslint": "^4.0.0",
     "eventemitter2": "^4.1.0",
     "file-type": "^5.0.0",
     "file-url": "^2.0.2",


### PR DESCRIPTION
Ref http://eslint.org/blog/2017/06/eslint-v4.0.0-released

---

Depends, among other, on: https://github.com/airbnb/javascript/issues/1447

```bash
npm WARN eslint-config-airbnb-base@11.2.0 requires a peer of eslint@^3.19.0 but none was installed.
npm WARN eslint-plugin-import@2.3.0 requires a peer of eslint@2.x - 3.x but none was installed.
```
