### PR TITLE
Fixes #287 - Avoid encoding JavaScript regular expressions in strings…

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lockfile": "^1.0.3",
     "lodash": "^4.17.4",
     "mime-db": "^1.28.0",
+    "minimatch": "^3.0.4",
     "mkdirp": "^0.5.1",
     "node-ssllabs": "^0.5.0",
     "optionator": "^0.8.2",

--- a/tests/lib/sonar.ts
+++ b/tests/lib/sonar.ts
@@ -298,7 +298,7 @@ test(`If an event is emitted for an ignored url, it shouldn't propagate`, async 
 
     const sonarObject = new sonar.Sonar({ //eslint-disable-line no-unused-vars
         collector: 'collector',
-        ignoredUrls: { '.*\\.domain1\.com/.*': ['*'] }, //eslint-disable-line no-useless-escape
+        ignoredUrls: { '*//*.domain1.com/**': ['*'] }, //eslint-disable-line no-useless-escape
         rules: { 'disallowed-headers': 'warning' }
     });
 
@@ -326,7 +326,7 @@ test.serial(`If a rule is ignoring some url, it shouldn't run the event`, (t) =>
 
     const sonarObject = new sonar.Sonar({ //eslint-disable-line no-unused-vars
         collector: 'collector',
-        ignoredUrls: { '.*\\.domain1\.com/.*': ['disallowed-headers'], '.*\\.domain2\.com/.*': ['disallowed-headers'] }, //eslint-disable-line no-useless-escape
+        ignoredUrls: { '*//*.domain1.com/**': ['disallowed-headers'], '*//*.domain2.com/**': ['disallowed-headers'] }, //eslint-disable-line no-useless-escape
         rules: { 'disallowed-headers': 'warning' }
     });
 


### PR DESCRIPTION
… in favor of glob patterns.

/cc @molant @patrick-steele-idem I'm putting up this PR to continue the conversation. After implementing this, I'm not convinced that it is the right solution. Glob patterns may not provide the flexibility necessary for this type of operation. Let me know your thoughts.

For example:

`*.domain1.com/**`
- Matches: `hello.domain1.com/world`
- Does not match: `http://www.domain1.com/world`

Let me know your thoughts, so we can decide whether to move forward with this approach, change the implementation, or simply close the PR and stick with the current approach.