### PR TITLE
Contributors page update

### DIFF
--- a/docs/about/CONTRIBUTORS.md
+++ b/docs/about/CONTRIBUTORS.md
@@ -1,10 +1,17 @@
 # Contributors
 
-* [Stephanie (Stimac) Drescher ![image](https://avatars1.githubusercontent.com/u/18073131?v=3&s=100)](https://github.com/ststimac)
-* [David García ![image](https://avatars1.githubusercontent.com/u/1581288?v=3&s=100)](https://github.com/sarvaje)
-* [Catalin Maris ![image](https://avatars2.githubusercontent.com/u/1223565?v=3&s=100)](https://github.com/alrra)
-* [Antón Molleda ![image](https://avatars2.githubusercontent.com/u/606594?v=3&s=100)](https://github.com/molant)
-* [Qing Zhou ![image](https://avatars3.githubusercontent.com/u/20218531?v=3&s=100)](https://github.com/qzhou1607)
+<!-- Contributors START
+Stephanie_Stimac_Drescher ststimac https://github.com/ststimac Design Code
+David_Garcia sarvaje https://github.com/sarvaje Code
+Catalin_Maris alrra https://github.com/alrra Code
+Antón_Molleda molant https://github.com/molant Code
+Qing_Zhou qzhou1607 https://github.com/qzhou1607 Code
+Contributors END -->
+<!-- Contributors table START -->
+| <img src="https://avatars.githubusercontent.com/ststimac?s=100" width="100" alt="Stephanie Stimac Drescher" /><br /><sub>Stephanie Stimac Drescher</sub>](https://github.com/ststimac)<br />undefined undefined | <img src="https://avatars.githubusercontent.com/sarvaje?s=100" width="100" alt="David Garcia" /><br /><sub>David Garcia</sub>](https://github.com/sarvaje)<br />undefined | <img src="https://avatars.githubusercontent.com/alrra?s=100" width="100" alt="Catalin Maris" /><br /><sub>Catalin Maris</sub>](https://github.com/alrra)<br />undefined | <img src="https://avatars.githubusercontent.com/molant?s=100" width="100" alt="Antón Molleda" /><br /><sub>Antón Molleda</sub>](https://github.com/molant)<br />undefined | <img src="https://avatars.githubusercontent.com/qzhou1607?s=100" width="100" alt="Qing Zhou" /><br /><sub>Qing Zhou</sub>](https://github.com/qzhou1607)<br />undefined |
+| :---: | :---: | :---: | :---: | :---: |
+<!-- Contributors table END -->
+This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
 
 ## Sponsors
 

--- a/docs/about/CONTRIBUTORS.md
+++ b/docs/about/CONTRIBUTORS.md
@@ -1,16 +1,10 @@
 # Contributors
 
-<!-- Contributors START
-Stephanie_Stimac_Drescher ststimac https://github.com/ststimac code design
-David_Garcia sarvaje https://github.com/sarvaje code
-Catalin_Maris alrra https://github.com/alrra code
-Antón_Molleda molant https://github.com/molant code
-Qing_Zhou qzhou1607 https://github.com/qzhou1607 code
-Contributors END -->
-<!-- Contributors table START -->
-| [<img src="https://avatars.githubusercontent.com/ststimac?s=100" width="100" alt="Stephanie Stimac Drescher" /><br /><sub>Stephanie Stimac Drescher</sub>](https://github.com/ststimac)<br />💻 🎨 | [<img src="https://avatars.githubusercontent.com/sarvaje?s=100" width="100" alt="David Garcia" /><br /><sub>David Garcia</sub>](https://github.com/sarvaje)<br />💻 | [<img src="https://avatars.githubusercontent.com/alrra?s=100" width="100" alt="Catalin Maris" /><br /><sub>Catalin Maris</sub>](https://github.com/alrra)<br />💻 | [<img src="https://avatars.githubusercontent.com/molant?s=100" width="100" alt="Antón Molleda" /><br /><sub>Antón Molleda</sub>](https://github.com/molant)<br />💻 | [<img src="https://avatars.githubusercontent.com/qzhou1607?s=100" width="100" alt="Qing Zhou" /><br /><sub>Qing Zhou</sub>](https://github.com/qzhou1607)<br />💻 |
+<!-- markdownlint-disable MD033 -->
+| [<img src="https://avatars.githubusercontent.com/ststimac?s=100" width="100" alt="Stephanie Stimac Drescher" /><br><sub>Stephanie Stimac Drescher</sub>](https://github.com/ststimac)<br><sub>Microsoft</sub><br>💻 🎨 | [<img src="https://avatars.githubusercontent.com/sarvaje?s=100" width="100" alt="David García" /><br><sub>David García</sub>](https://github.com/sarvaje)<br><sub>Plain Concepts</sub><br>💻 | [<img src="https://avatars.githubusercontent.com/alrra?s=100" width="100" alt="Cătălin Mariș" /><br><sub>Cătălin Mariș</sub>](https://github.com/alrra)<br><sub>Microsoft</sub><br>💻 | [<img src="https://avatars.githubusercontent.com/molant?s=100" width="100" alt="Antón Molleda" /><br><sub>Antón Molleda</sub>](https://github.com/molant)<br><sub>Microsoft</sub><br>💻 | [<img src="https://avatars.githubusercontent.com/qzhou1607?s=100" width="100" alt="Qing Zhou" /><br><sub>Qing Zhou</sub>](https://github.com/qzhou1607)<br><sub>Plain Concepts</sub><br>💻 |
 | :---: | :---: | :---: | :---: | :---: |
-<!-- Contributors table END -->
+<!-- markdownlint-enable MD033 -->
+
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.
 
 ## Sponsors

--- a/docs/about/CONTRIBUTORS.md
+++ b/docs/about/CONTRIBUTORS.md
@@ -1,14 +1,14 @@
 # Contributors
 
 <!-- Contributors START
-Stephanie_Stimac_Drescher ststimac https://github.com/ststimac Design Code
-David_Garcia sarvaje https://github.com/sarvaje Code
-Catalin_Maris alrra https://github.com/alrra Code
-Antón_Molleda molant https://github.com/molant Code
-Qing_Zhou qzhou1607 https://github.com/qzhou1607 Code
+Stephanie_Stimac_Drescher ststimac https://github.com/ststimac code design
+David_Garcia sarvaje https://github.com/sarvaje code
+Catalin_Maris alrra https://github.com/alrra code
+Antón_Molleda molant https://github.com/molant code
+Qing_Zhou qzhou1607 https://github.com/qzhou1607 code
 Contributors END -->
 <!-- Contributors table START -->
-| <img src="https://avatars.githubusercontent.com/ststimac?s=100" width="100" alt="Stephanie Stimac Drescher" /><br /><sub>Stephanie Stimac Drescher</sub>](https://github.com/ststimac)<br />undefined undefined | <img src="https://avatars.githubusercontent.com/sarvaje?s=100" width="100" alt="David Garcia" /><br /><sub>David Garcia</sub>](https://github.com/sarvaje)<br />undefined | <img src="https://avatars.githubusercontent.com/alrra?s=100" width="100" alt="Catalin Maris" /><br /><sub>Catalin Maris</sub>](https://github.com/alrra)<br />undefined | <img src="https://avatars.githubusercontent.com/molant?s=100" width="100" alt="Antón Molleda" /><br /><sub>Antón Molleda</sub>](https://github.com/molant)<br />undefined | <img src="https://avatars.githubusercontent.com/qzhou1607?s=100" width="100" alt="Qing Zhou" /><br /><sub>Qing Zhou</sub>](https://github.com/qzhou1607)<br />undefined |
+| [<img src="https://avatars.githubusercontent.com/ststimac?s=100" width="100" alt="Stephanie Stimac Drescher" /><br /><sub>Stephanie Stimac Drescher</sub>](https://github.com/ststimac)<br />💻 🎨 | [<img src="https://avatars.githubusercontent.com/sarvaje?s=100" width="100" alt="David Garcia" /><br /><sub>David Garcia</sub>](https://github.com/sarvaje)<br />💻 | [<img src="https://avatars.githubusercontent.com/alrra?s=100" width="100" alt="Catalin Maris" /><br /><sub>Catalin Maris</sub>](https://github.com/alrra)<br />💻 | [<img src="https://avatars.githubusercontent.com/molant?s=100" width="100" alt="Antón Molleda" /><br /><sub>Antón Molleda</sub>](https://github.com/molant)<br />💻 | [<img src="https://avatars.githubusercontent.com/qzhou1607?s=100" width="100" alt="Qing Zhou" /><br /><sub>Qing Zhou</sub>](https://github.com/qzhou1607)<br />💻 |
 | :---: | :---: | :---: | :---: | :---: |
 <!-- Contributors table END -->
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification.


### PR DESCRIPTION
Resolves issue #279 

Using https://github.com/kentcdodds/all-contributors to clean up the Contributors page

Have to manually remove the links to user/project commit history that gets generated with the icon. Looking over the readme.md for all-contributors, I can't tell if there's a way to just use the icon and not add a link. 

Also people may want to edit their contribution categories at some point.