### PR TITLE
Fix failing request test using hardcoded port.

### DIFF
--- a/tests/lib/collectors/utils/requester.ts
+++ b/tests/lib/collectors/utils/requester.ts
@@ -190,5 +190,5 @@ test(`Aborts the request if it exceeds the time limit to get response`, async (t
     const { error, uri } = await t.throws(timeoutRequester.get(`http://localhost:${server.port}/timeout`));
 
     t.is(error.code, 'ESOCKETTIMEDOUT');
-    t.is(uri, 'http://localhost:3058/timeout');
+    t.is(uri, `http://localhost:${server.port}/timeout`);
 });


### PR DESCRIPTION
This test is failing because of the hardcoded port.