### PR TITLE
Specify required node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,9 @@
     "typescript": "^2.3.3",
     "typescript-eslint-parser": "^3.0.0"
   },
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "files": [
     ".sonarrc",
     "dist",


### PR DESCRIPTION
With this field npm will show a warning and Yarn will prevent the installation if the package is installed with an unsupported node version.