### PR TITLE
Typo in example page

### DIFF
--- a/docs/user-guide/rules/no-friendly-error-pages.md
+++ b/docs/user-guide/rules/no-friendly-error-pages.md
@@ -46,7 +46,7 @@ HTTP/... 403 Forbidden
         <meta charset="utf-8">
         <title>403 Forbidden</title>
     </head>
-    <body>This page has under 256 bytes, so it will be displayed by all browsers.</body>
+    <body>This page has under 256 bytes, so it will not be displayed by all browsers.</body>
 </html>
 ```
 


### PR DESCRIPTION
There is a missing *not* in the 403 page example