### PR TITLE
Fix typo in cli scan::start output (Analizing)

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -39,7 +39,7 @@ const messages = {
     'manifestfetch::end': '%url% downloaded',
     'manifestfetch::start': 'Downloading %url%',
     'scan::end': 'Finishing...',
-    'scan::start': 'Analizing %url%',
+    'scan::start': 'Analyzing %url%',
     'targetfetch::end': '%url% downloaded',
     'targetfetch::start': 'Downloading %url%',
     'traverse::down': 'Traversing the DOM',


### PR DESCRIPTION
Repro:
1) At the command line, run “sonar www.example.com”
2) Observe the first line of output
Expected: “Analyzing…”
Actual: “Analyzing…”