### PR TITLE
283 - Improve rules configuration. Allow rules to be an array.

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -30,11 +30,11 @@ them and you will end up with something similar to the following:
         "name": "collectorName"
     },
     "formatter": "formatterName",
-    "rules": {
-        "rule1": "error",
-        "rule2": "error",
-        "rule3": "error"
-    },
+    "rules": [
+        "rule1",
+        "rule2:warning",
+        "rule3:off"
+    ],
     "rulesTimeout": 120000
 }
 ```
@@ -77,16 +77,53 @@ should have:
 * `error`: The rule will be executed and will change the exit status
   code to `1` if an issue is found.
 
+Rules can be configured using the array or object syntax:
+
+```json
+{
+    "rules": [
+        "rule1:warning"
+    ]
+}
+```
+
+```json
+{
+    "rules": {
+        "rule1": "warning"
+    }
+}
+```
+
+The `off` and `warning` rule severities may be applied with shorthand
+characters `-` and `?` respectfully when using the array syntax:
+
+A rule that has the `off` severity applied:
+
+```json
+"rules": [
+    "-rule1"
+]
+```
+
+A rule that has the `warning` severity applied:
+
+```json
+"rules": [
+    "?rule1"
+]
+```
+
 Additionally, some rules allow further customization. The configuration
 in that case it will be similar to the following:
 
 ```json
-"rules": {
-    "rule1": ["severity", {
+"rules": [
+    ["rule1:warning", {
         "customization1": "value1",
         "customization2": "value2"
     }]
-}
+]
 ```
 
 You can check which rules accept this kind of configuration by

--- a/src/lib/sonar.ts
+++ b/src/lib/sonar.ts
@@ -19,6 +19,7 @@ import { getSeverity } from './config/config-rules';
 import { IAsyncHTMLElement, ICollector, ICollectorBuilder, IConfig, IEvent, IProblem, IProblemLocation, IRule, IRuleBuilder, IRuleConfigList, IPlugin, RuleConfig, Severity, URL } from './types'; // eslint-disable-line no-unused-vars
 import * as logger from './utils/logging';
 import * as resourceLoader from './utils/resource-loader';
+import normalizeRules from './utils/normalize-rules';
 import { RuleContext } from './rule-context';
 
 const debug: debug.IDebugger = d(__filename);
@@ -137,6 +138,8 @@ export class Sonar extends EventEmitter {
         if (!config.rules) {
             return;
         }
+
+        config.rules = normalizeRules(config.rules);
 
         const rules: Map<string, IRuleBuilder> = resourceLoader.loadRules(config.rules);
         const rulesIds: Array<string> = Object.keys(config.rules);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,7 +38,7 @@ export interface IIgnoredUrlList {
 
 export interface IConfig {
     collector: ICollectorConfig | string;
-    rules?: IRuleConfigList;
+    rules?: IRuleConfigList | Array<RuleConfig>;
     browserslist?: string | Array<string>;
     rulesTimeout?: number;
     formatter?: string;

--- a/src/lib/utils/normalize-rules.ts
+++ b/src/lib/utils/normalize-rules.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Used for normalizing rules that are passed as configuration.
+ * Rules are stored as objects internally, so this module converts rule arrays
+ * to objects or if an object is passed, it returns it.
+ */
+
+const DEFAULT_RULE_LEVEL = 'error';
+
+const shortHandRulePrefixes = {
+    '-': 'off',
+    '?': 'warning'
+};
+
+interface NormalizedRule extends Object {
+    ruleLevel: string;
+    ruleName: string;
+}
+
+const normalizeRule = (rule: string): NormalizedRule => {
+    let ruleLevel: string;
+    let ruleName: string;
+
+    for (const prefix in shortHandRulePrefixes) {
+        if (rule.startsWith(prefix)) {
+            // Matches for rule like: `?rule1`
+            ruleLevel = shortHandRulePrefixes[prefix];
+            ruleName = rule.substr(1, rule.length - 1);
+            break;
+        }
+    }
+
+    if (!ruleLevel) {
+        // Matches for a rule like: `rule1` or `rule1:warn`
+        [ruleName, ruleLevel] = rule.split(':');
+        ruleLevel = ruleLevel || DEFAULT_RULE_LEVEL;
+    }
+
+    return {
+        ruleLevel,
+        ruleName
+    };
+};
+
+/**
+ * Normalized all rules passed as configuration
+ * Ex.:
+ * * ["rule1"] => { "rule1": "error" }
+ * * { "rule1": "warning" } => { "rule1": "warning" }
+ * * ["rule1:warning"] => { "rule1": "warning" }
+ */
+export default function normalizeRules (rules) {
+    if (!Array.isArray(rules)) {
+        return rules;
+    }
+
+    const result = {};
+
+    rules.forEach((rule) => {
+        if (typeof rule === 'string') {
+            const { ruleName, ruleLevel } = normalizeRule(rule);
+
+            result[ruleName] = ruleLevel;
+        } else if (Array.isArray(rule)) {
+            const [ruleKey, ruleConfig] = rule;
+            const { ruleName, ruleLevel } = normalizeRule(ruleKey);
+
+            result[ruleName] = [ruleLevel];
+
+            if (ruleConfig) {
+                result[ruleName].push(ruleConfig);
+            }
+        } else {
+            throw new Error(`Invalid rule type specified: "${rule}". Arrays and objects are supported.`);
+        }
+    });
+
+    return result;
+}

--- a/tests/lib/sonar.ts
+++ b/tests/lib/sonar.ts
@@ -142,7 +142,6 @@ test.serial('If config.rules is an object with rules, we should create just thos
     t.context.rule = rule;
     sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
         ['disallowed-headers', rule],
-        ['lang-attribute', rule],
         ['manifest-exists', rule]
     ]));
     sinon.stub(rule, 'create')
@@ -180,7 +179,6 @@ test.serial(`If config.rules has some rules "off", we shouldn't create those rul
     t.context.rule = rule;
     sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
         ['disallowed-headers', rule],
-        ['lang-attribute', rule],
         ['manifest-exists', rule]
     ]));
     sinon.stub(rule, 'create').returns({ 'fetch::end': () => { } });
@@ -199,6 +197,139 @@ test.serial(`If config.rules has some rules "off", we shouldn't create those rul
     t.context.eventemitter.prototype.on.restore();
 });
 
+test.serial('If config.rules is an array with rules, we should create just those rules', (t) => {
+    const rule = {
+        create() {
+            return {};
+        },
+        meta: {}
+    };
+
+    sinon.spy(eventEmitter.EventEmitter2.prototype, 'on');
+    t.context.rule = rule;
+    sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
+        ['disallowed-headers', rule],
+        ['manifest-exists', rule]
+    ]));
+    sinon.stub(rule, 'create')
+        .onFirstCall()
+        .returns({ 'fetch::end': () => { } })
+        .onSecondCall()
+        .returns({ 'fetch::error': () => { } });
+
+    const sonarObject = new Sonar({ //eslint-disable-line no-unused-vars
+        collector: 'collector',
+        rules: [
+            'disallowed-headers:warning',
+            'manifest-exists:warning'
+        ]
+    });
+
+    t.true(t.context.resourceLoader.loadRules.called);
+    t.true(t.context.rule.create.calledTwice);
+    t.true(t.context.eventemitter.prototype.on.calledTwice);
+    t.is(t.context.eventemitter.prototype.on.args[0][0], 'fetch::end');
+    t.is(t.context.eventemitter.prototype.on.args[1][0], 'fetch::error');
+
+    t.context.eventemitter.prototype.on.restore();
+});
+
+test.serial(`If config.rules is an array and has some rules "off", we shouldn't create those rules`, (t) => {
+    const rule = {
+        create() {
+            return {};
+        },
+        meta: {}
+    };
+
+    sinon.spy(eventEmitter.EventEmitter2.prototype, 'on');
+    t.context.rule = rule;
+    sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
+        ['disallowed-headers', rule],
+        ['manifest-exists', rule]
+    ]));
+    sinon.stub(rule, 'create').returns({ 'fetch::end': () => { } });
+
+    const sonarObject = new Sonar({ //eslint-disable-line no-unused-vars
+        collector: 'collector',
+        rules: [
+            'disallowed-headers:warning',
+            'manifest-exists:off'
+        ]
+    });
+
+    t.true(t.context.resourceLoader.loadRules.called);
+    t.true(t.context.rule.create.calledOnce);
+
+    t.context.eventemitter.prototype.on.restore();
+});
+
+test.serial('If config.rules is an array with shorthand warning rules, we should create just those rules', (t) => {
+    const rule = {
+        create() {
+            return {};
+        },
+        meta: {}
+    };
+
+    sinon.spy(eventEmitter.EventEmitter2.prototype, 'on');
+    t.context.rule = rule;
+    sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
+        ['disallowed-headers', rule],
+        ['manifest-exists', rule]
+    ]));
+    sinon.stub(rule, 'create')
+        .onFirstCall()
+        .returns({ 'fetch::end': () => { } })
+        .onSecondCall()
+        .returns({ 'fetch::error': () => { } });
+
+    const sonarObject = new Sonar({ //eslint-disable-line no-unused-vars
+        collector: 'collector',
+        rules: [
+            '?disallowed-headers',
+            'manifest-exists:warning'
+        ]
+    });
+
+    t.true(t.context.resourceLoader.loadRules.called);
+    t.true(t.context.rule.create.calledTwice);
+    t.true(t.context.eventemitter.prototype.on.calledTwice);
+    t.is(t.context.eventemitter.prototype.on.args[0][0], 'fetch::end');
+    t.is(t.context.eventemitter.prototype.on.args[1][0], 'fetch::error');
+
+    t.context.eventemitter.prototype.on.restore();
+});
+
+test.serial(`If config.rules is an array and has some rules "off", we shouldn't create those rules`, (t) => {
+    const rule = {
+        create() {
+            return {};
+        },
+        meta: {}
+    };
+
+    sinon.spy(eventEmitter.EventEmitter2.prototype, 'on');
+    t.context.rule = rule;
+    sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
+        ['disallowed-headers', rule],
+        ['manifest-exists', rule]
+    ]));
+    sinon.stub(rule, 'create').returns({ 'fetch::end': () => { } });
+
+    const sonarObject = new Sonar({ //eslint-disable-line no-unused-vars
+        collector: 'collector',
+        rules: [
+            'disallowed-headers:warning',
+            '-manifest-exists'
+        ]
+    });
+
+    t.true(t.context.resourceLoader.loadRules.called);
+    t.true(t.context.rule.create.calledOnce);
+
+    t.context.eventemitter.prototype.on.restore();
+});
 test.serial(`If a rule has the metadata "ignoredCollectors" set up, we shouldn't ignore those rules if the collector isn't in that property`, (t) => {
     const rule = {
         create() {
@@ -211,7 +342,6 @@ test.serial(`If a rule has the metadata "ignoredCollectors" set up, we shouldn't
     t.context.rule = rule;
     sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
         ['disallowed-headers', rule],
-        ['lang-attribute', rule],
         ['manifest-exists', rule]
     ]));
     sinon.stub(rule, 'create')
@@ -256,7 +386,6 @@ test.serial(`If a rule has the metadata "ignoredCollectors" set up, we should ig
     t.context.ruleWithIgnoredCollector = ruleWithIgnoredCollector;
     sinon.stub(t.context.resourceLoader, 'loadRules').returns(new Map([
         ['disallowed-headers', ruleWithIgnoredCollector],
-        ['lang-attribute', rule],
         ['manifest-exists', rule]
     ]));
     sinon.stub(rule, 'create').returns({ 'fetch::end': () => { } });

--- a/tests/lib/utils/normalize-rules.ts
+++ b/tests/lib/utils/normalize-rules.ts
@@ -1,0 +1,64 @@
+import test from 'ava';
+import normalizeRules from '../../../src/lib/utils/normalize-rules';
+
+test(`should normalize basic rules`, (t) => {
+    const rules = [
+        'rule1',
+        'rule2:error',
+        'rule3:warning',
+        'rule4:off'
+    ];
+
+    const expected = {
+        rule1: 'error',
+        rule2: 'error',
+        rule3: 'warning',
+        rule4: 'off'
+    };
+
+    t.deepEqual(normalizeRules(rules), expected);
+});
+
+test(`should normalize rules including array`, (t) => {
+    const rules = [
+        'rule1',
+        ['rule2', { customization1: 'value1'}]
+    ];
+
+    const expected = {
+        rule1: 'error',
+        rule2: ['error', { customization1: 'value1' }]
+    };
+
+    t.deepEqual(normalizeRules(rules), expected);
+});
+
+test(`should normalize rules with shorthand prefixes`, (t) => {
+    const rules = [
+        '?rule1',
+        '-rule2',
+        ['?rule3', { customization1: 'value1' }]
+    ];
+
+    const expected = {
+        rule1: 'warning',
+        rule2: 'off',
+        rule3: ['warning', { customization1: 'value1' }]
+    };
+
+    t.deepEqual(normalizeRules(rules), expected);
+});
+
+test(`should throw invalid rule specified error when providing invalid rule`, (t) => {
+    const rules = [1];
+
+    t.throws(() => {
+        normalizeRules(rules);
+    }, 'Invalid rule type specified: "1". Arrays and objects are supported.');
+});
+
+test(`should maintain backwards compatibility by returning objects`, (t) => {
+    const rules = { rule1: 'error' };
+
+    t.deepEqual(normalizeRules(rules), rules);
+});


### PR DESCRIPTION
**Do not merge** until the issue with the build not working on UNIX systems is fixed. The tests were passing, but I've made a few more changes without running the tests (since I can't right now). The Travis tests will obviously fail because the build is not passing at the moment. I just wanted to get any feedback from @molant before he leaves on vacation.

This change allows arrays to be passed for `rules` in the config:

```
{
    "rules": [
        "rule1",        // Default to "error"
        "rule2:warn",   // Switch to warn
        "rule3:off",    // Quickly disable a rule
        ["rule4", {
            something: true
        }]
    ]
}
```

It also allows for `warn` and `off` shorthands:

```
{
    "rules": [
    "rule1",          // Default to "error"
    "?rule2",        // Switch to warn
    "-rule3"        // Quickly disable a rule
}
```

My change is backwards compatible, so passing objects is still supported:

```
{
    "rules": {
        "rule1": "warning",
        "rule2": "off"
    }
}
```