### PR TITLE
Increase default used `waitFor` time to 1s

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -2,7 +2,7 @@
     "collector": {
         "name": "cdp",
         "options": {
-            "waitFor": 100,
+            "waitFor": 1000,
             "loadCompleteRetryInterval": 500,
             "maxLoadWaitTime": 30000
         }

--- a/src/lib/cli/sonarrc-generator.ts
+++ b/src/lib/cli/sonarrc-generator.ts
@@ -1,6 +1,5 @@
 /**
  * @fileoverview Generates a valid `.sonarrc` file based on user responses.
- *
  */
 
 // ------------------------------------------------------------------------------
@@ -39,7 +38,7 @@ export const initSonarrc = async () => {
         browserslist: '',
         collector: {
             name: '',
-            options: {}
+            options: { waitFor: 1000 }
         },
         formatter: 'stylish',
         ignoredUrls: {},

--- a/tests/lib/config/config-validator.ts
+++ b/tests/lib/config/config-validator.ts
@@ -6,7 +6,7 @@ import * as configValidator from '../../../src/lib/config/config-validator';
 const validConfig = {
     collector: {
         name: 'cdp',
-        options: { waitFor: 100 }
+        options: { waitFor: 1000 }
     },
     formatter: 'json',
     rules: {

--- a/tests/lib/fixtures/getFilenameForDirectory/.sonarrc
+++ b/tests/lib/fixtures/getFilenameForDirectory/.sonarrc
@@ -2,7 +2,7 @@
     "collector": {
         "name": "cdp",
         "options": {
-            "waitFor": 100
+            "waitFor": 1000
         }
     },
     "formatter": "json",

--- a/tests/lib/fixtures/notvalid/notvalid.css
+++ b/tests/lib/fixtures/notvalid/notvalid.css
@@ -2,7 +2,7 @@
     "collector": {
         "name": "cdp",
         "options": {
-            "waitFor": 100
+            "waitFor": 1000
         }
     },
     "formatter": "json",

--- a/tests/lib/fixtures/package.json
+++ b/tests/lib/fixtures/package.json
@@ -4,7 +4,7 @@
     "collector": {
       "name": "cdp",
       "options": {
-        "waitFor": 100
+        "waitFor": 1000
       }
     },
     "formatter": "json",

--- a/tests/lib/fixtures/sonarrc
+++ b/tests/lib/fixtures/sonarrc
@@ -2,7 +2,7 @@
     "collector": {
         "name": "cdp",
         "options": {
-            "waitFor": 100
+            "waitFor": 1000
         }
     },
     "formatter": "json",

--- a/tests/lib/fixtures/sonarrc.js
+++ b/tests/lib/fixtures/sonarrc.js
@@ -1,7 +1,7 @@
 module.exports = {
     collector: {
         name: 'cdp',
-        options: { waitFor: 100 }
+        options: { waitFor: 1000 }
     },
     formatter: 'json',
     rules: {


### PR DESCRIPTION
Having a short `waitFor` time causes some problems with CDP, namely: "Error: Could not find node with given id".

---

Ref #275
Fix #275