### PR TITLE
Disable `ssllabs` rule by default

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -22,7 +22,7 @@
         "no-friendly-error-pages": "warning",
         "no-html-only-headers": "warning",
         "no-protocol-relative-urls": "warning",
-        "ssllabs": "warning",
+        "ssllabs": "off",
         "x-content-type-options": "warning"
     }
 }

--- a/src/lib/rules/ssllabs/ssllabs.ts
+++ b/src/lib/rules/ssllabs/ssllabs.ts
@@ -163,7 +163,7 @@ There might be something wrong with SSL Labs servers.`;
             description: 'Strength of your SSL configuration'
         },
         fixable: 'none',
-        recommended: true,
+        recommended: false,
         schema: [{
             additionalProperties: false,
             properties: {


### PR DESCRIPTION
The `ssllabs` rule takes quite a lot of time to complete, so for users that don't know that, it might seem like things are stuck.

So, for the time being, don't include the `ssllabs` rule by default, only if the user specifically requested it.

---

Ref: https://github.com/sonarwhal/sonar/issues/354#issuecomment-312577470