### PR TITLE
Improve documentations

### DIFF
--- a/docs/developer-guide/connectors/events.md
+++ b/docs/developer-guide/connectors/events.md
@@ -11,6 +11,7 @@ the events common to all `connector`s, with their signature, and the
 * [`manifestfetch::end`](#manifestfetchend)
 * [`manifestfetch::error`](#manifestfetcherror)
 * [`manifestfetch::start`](#manifestfetchstart)
+* [`manifestfetch::missing`](#manifestfetchmissing)
 * [`scan::end`](#scanend)
 * [`scan::start`](#scanstart)
 * [`targetfetch::end`](#targetfetchend)
@@ -59,7 +60,7 @@ export interface IFetchEnd {
 }
 ```
 
-**Note:** The event is the same for [`targetfetch::end`](#targetfetchend).
+**Note:** This is a basic event interface that [`targetfetch::end`](#targetfetchend) and [`manifestfetch::end`](#manifestfetchend) extend from.
 
 ## `fetch::error`
 
@@ -76,10 +77,12 @@ export interface IFetchError {
     element: IAsyncHTMLElement;
     /** The error found. */
     error: any;
+    /** The redirects performed for the url. */
+    hops: Array<string>
 }
 ```
 
-**Note:** The event is the same for [`targetfetch::error`](#targetfetcherror).
+**Note:** This event has the same interface as [`targetfetch::error`](#targetfetcherror).
 
 ## `fetch::start`
 
@@ -95,7 +98,7 @@ export interface IFetchStart {
 }
 ```
 
-**Note:** The event is the same for [`targetfetch::start`](#targetfetchstart).
+**Note:** This is a basic event interface that [`targetfetch::start`](#targetfetchstart) extends from.
 
 ## `manifestfetch::end`
 
@@ -105,7 +108,7 @@ the web manifest of a page.
 **Format:**
 
 ```ts
-export interface IFetchEndEvent {
+export interface IManifestFetchEnd {
     /** The element that initiated the request. */
     element: IAsyncHTMLElement;
     /** The URL of the target */
@@ -117,7 +120,23 @@ export interface IFetchEndEvent {
 }
 ```
 
-**Note:** The event is the same for [`targetfetch::end`](#targetfetchend).
+**Note:** This event interface extends from [`fetch::end`](#fetchend).
+
+## `manifestfetch::start`
+
+Event is emitted **when** the `connector` is about to start downloading
+the web manifest.
+
+**Format:**
+
+```ts
+export interface IFetchStart {
+    /** The URL to download */
+    resource: string;
+}
+```
+
+**Note::** This event has the same interface as [`fetch::start`](#fetchstart).
 
 ## `manifestfetch::error`
 
@@ -127,15 +146,13 @@ downloading the web manifest.
 **Format:**
 
 ```ts
-export interface IFetchErrorEvent {
+export interface IManifestFetchError {
     /** The URL of the target. */
     resource: string;
     /** The error found. */
     error: any;
 }
 ```
-
-**Note:** The event is the same for [`targetfetch::error`](#targetfetcherror).
 
 ## `manifestfetch::missing`
 
@@ -145,13 +162,11 @@ download.
 **Format:**
 
 ```ts
-export interface IManifestFetchMissingEvent {
+export interface IManifestFetchMissing {
     /** The URL to download */
     resource: string;
 }
 ```
-
-**Note:** The event is the same for [`targetfetch::start`](#targetfetchstart).
 
 ## `scan::end`
 
@@ -195,7 +210,7 @@ the `target`.
 **Format:**
 
 ```ts
-export interface IFetchEnd {
+export interface ITargetFetchEnd {
     /** The element that initiated the request. */
     element: IAsyncHTMLElement;
     /** The URL of the target. */
@@ -207,7 +222,7 @@ export interface IFetchEnd {
 }
 ```
 
-**Note:** The event is the same for [`fetch::end`](#fetchend).
+**Note:** This event interface extends from [`fetch::end`](#fetchend).
 In this case `element` will be `null`.
 
 ## `targetfetch::error`
@@ -228,7 +243,7 @@ export interface IFetchError {
 }
 ```
 
-**Note::** The event is the same for [`fetch::error`](#fetcherror).
+**Note::** This event has the same interface as [`fetch::error`](#fetcherror).
 In this case `element` will be `null`.
 
 ## `targetfetch::start`
@@ -239,13 +254,13 @@ request to fetch the `target`. Redirects are followed if needed.
 **Format:**
 
 ```typescript
-export interface IFetchStart {
+export interface ITargetFetchStart {
     /** The URL to download */
     resource: string;
 }
 ```
 
-**Note::** The event is the same for [`fetch::start`](#fetchstart).
+**Note::** This event interface extends from [`fetch::start`](#fetchstart).
 
 ## `traverse::down`
 

--- a/docs/developer-guide/rules/index.md
+++ b/docs/developer-guide/rules/index.md
@@ -15,22 +15,22 @@ The following is a basic template for a core rule (you might need to
 adapt the paths for your case):
 
 ```ts
-import { IFetchEndEvent, IRule, IRuleBuilder } from '../../types'; // eslint-disable-line no-unused-vars
+import { IFetchEnd, IRule, IRuleBuilder } from '../../types'; // eslint-disable-line no-unused-vars
 import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
 
 const rule: IRuleBuilder = {
     create(context: RuleContext): IRule {
         // Your code here.
 
-        const validateFetchEnd = (fetchEnd: IFetchEndEvent) => {
+        const validateFetchEnd = (fetchEnd: IFetchEnd) => {
             // Code to validate the rule on the event fetch::end.
         }
 
-        const validateTargetFetchEnd = (targetFetchEnd: IFetchEndEvent) => {
+        const validateTargetFetchEnd = (targetFetchEnd: IFetchEnd) => {
             // Code to validate the rule on the event targetfetch::end.
         }
 
-        const validateElement = (element: IElementFoundEvent) => {
+        const validateElement = (element: IElementFound) => {
             // Code to validate the rule on the event element::element-type.
         }
 

--- a/docs/user-guide/rules/content-type.md
+++ b/docs/user-guide/rules/content-type.md
@@ -6,7 +6,7 @@ the appropriate media type and charset for the response.
 
 ## Why is this important?
 
-Even thought browsers sometimes [ignore](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Configuring_server_MIME_types))
+Even thought browsers sometimes [ignore](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Configuring_server_MIME_types)
 the value of the `Content-Type` header and try to [sniff the content](https://mimesniff.spec.whatwg.org/),
 it's indicated to always send the appropriate media type and charset
 for the response as, among other:

--- a/docs/user-guide/rules/html-checker.md
+++ b/docs/user-guide/rules/html-checker.md
@@ -1,4 +1,4 @@
-# The Nu HTML Test (`html-checker`)
+# Nu HTML Test (`html-checker`)
 
 `html-checker` validates the markup of a website against the [Nu HTML checker](https://validator.github.io/validator/).
 

--- a/docs/user-guide/rules/x-content-type-options.md
+++ b/docs/user-guide/rules/x-content-type-options.md
@@ -30,7 +30,7 @@ Note: [Most modern browsers only respect the header for `script`s and
 (see also [whatwg/fetch#395](https://github.com/whatwg/fetch/issues/395).
 
 Going back to the previous example, if the `X-Content-Type-Options: nosniff`
-header is sent for the script, if the browser detects that its a script
+header is sent for the script, if the browser detects that it's a script
 and it wasn't served with one of the [JavaScript media
 type](https://html.spec.whatwg.org/multipage/scripting.html#javascript-mime-type),
 it will block it.

--- a/src/lib/types/events.ts
+++ b/src/lib/types/events.ts
@@ -12,7 +12,7 @@ export interface IScanStart extends IEvent { }
 /** The object emitted when the connector has finished the process. */
 export interface IScanEnd extends IEvent { }
 
-/** The object emitted by a connector on `targetfetch::start` or `fetch::start`. */
+/** The object emitted by a connector on `targetfetch::start`, `fetch::start` or `manifestfetch::start`. */
 export interface IFetchStart extends IEvent { }
 
 /** The object emitted by a connector on `targetfetch::end` or `fetch::end`. */
@@ -63,7 +63,7 @@ export interface IManifestFetchError extends IEvent {
 }
 
 /** The object emitted by a connector on `manifestfetch::missing`. */
-export interface IManifestFetchMissingEvent extends IEvent { }
+export interface IManifestFetchMissing extends IEvent { }
 
 /** The object emitted by a connector on ` manifestfetch::end`. */
 export interface IManifestFetchEnd extends IFetchEnd { }


### PR DESCRIPTION
Some updates made along the way of reading the rules.

One question - in the `event` documentation, under `manifest::missing`, it says "The event is the same for `targetfetch::start`". It doesn't look correct to me. Can you confirm? @alrra @molant 