### PR TITLE
Build: Remove `dist: trusty` from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     # https://github.com/travis-ci/travis-ci/issues/7181
 
     - os: linux
-      dist: trusty
 
       addons:
         chrome: stable


### PR DESCRIPTION
Starting tomorrow [Travis CI will default to Ubuntu Trusty 14.04](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming).

