### PR TITLE
Fix #389 Cannot read property 'response' of undefined when accessing inexistant url

### DIFF
--- a/tests/lib/connectors/invalid-url.ts
+++ b/tests/lib/connectors/invalid-url.ts
@@ -1,0 +1,38 @@
+import * as url from 'url';
+
+import test from 'ava';
+
+import { builders } from '../../helpers/connectors';
+
+import { IConnector, IConnectorBuilder, INetworkData } from '../../../src/lib/types'; // eslint-disable-line no-unused-vars
+
+test.beforeEach((t) => {
+    const sonar = {
+        emit() { },
+        emitAsync() { }
+    };
+
+    t.context = { sonar };
+});
+
+test.afterEach.always(async (t) => {
+    await t.context.connector.close();
+});
+
+const testConnectorInvalidUrl = (connectorInfo) => {
+    const connectorBuilder: IConnectorBuilder = connectorInfo.builder;
+    const name: string = connectorInfo.name;
+
+    test(`[${name}] Load an invalid url throws an error`, async (t) => {
+        const { sonar } = t.context;
+        const connector: IConnector = await (connectorBuilder)(sonar, {});
+
+        t.context.connector = connector;
+
+        await t.throws(connector.collect(url.parse('https://localhome')));
+    });
+};
+
+builders.forEach((connector) => {
+    testConnectorInvalidUrl(connector);
+});


### PR DESCRIPTION
Initial work. I'd like to add some tests to this but having some quiet time is a challenge at the moment.