### PR TITLE
New: Add rule to check `Set-Cookie` header

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -24,7 +24,8 @@
         "no-html-only-headers": "warning",
         "no-protocol-relative-urls": "warning",
         "ssllabs": "off",
+        "strict-transport-security": "warning",
         "x-content-type-options": "warning",
-        "strict-transport-security": "warning"
+        "validate-set-cookie-header": "warning"
     }
 }

--- a/docs/user-guide/rules/index.md
+++ b/docs/user-guide/rules/index.md
@@ -35,3 +35,4 @@
 * [`ssllabs`](ssllabs.md)
 * [`strict-transport-security`](strict-transport-security.md)
 * [`x-content-type-options`](x-content-type-options.md)
+* [`validate-set-cookie-header`](validate-set-cookie-header.md)

--- a/docs/user-guide/rules/validate-set-cookie-header.md
+++ b/docs/user-guide/rules/validate-set-cookie-header.md
@@ -1,0 +1,174 @@
+# Validate `Set-Cookie` Header (`validate-set-cookie-header`)
+
+This rule validates the `set-cookie` header and confirms that the
+`Secure` and `HttpOnly` directives are defined when sent from a
+secure origin (HTTPS).
+
+## Why is this important?
+
+A cookie is a small piece of information sent from a server to a
+user agent. The user agent might save it and send it along with
+future requests to identify the user session, track and analyze
+user behavior or inform the server of the user preferences.
+As a result, it contains sensitive data in a lot of the cases.
+To create a cookie, the `Set-Cookie` header is sent from a
+server in reponse to requests.
+
+In the `Set-Cookie` header, a cookie is defined by a name associated with a value.
+And a web server is allowed to configure the `domain` and `path`
+directives to restrain the scope of cookies. While session cookies
+are deleted when a browser shuts down, the permanent cookies
+expire at the time defined by `Expires` or `Max-Age`.
+
+Among the directives, the `Secure` and `HttpOnly` attributes
+are particularly relevant to the security of cookies:
+
+* Setting `Secure` directive forbids a cookie to be transmitted via simple HTTP.
+* Setting the `HttpOnly` directive prevents access to cookie value through javascript.
+
+Applying both of these directives makes it difficult to exploit
+cross-site scripting ([XSS][xss]) vulnerability and hijack the
+authenticated user sessions. The [wiki][http cookie wiki] page
+of `HTTP cookies` offers detailed examples of [cookie theft][cookie theft]
+and [proxy request][proxy request] when cookies are not well protected.
+According to the RFC [HTTP State Management Mechanism][HTTP State Management Mechanism],
+"When using cookies over a secure channel, servers SHOULD set the Secure attribute
+for every cookie". As a result, this rule checks if `Secure` and `HttpOnly` directives
+are properly used, and also offers to validate the `Set-Cookie` header syntax.
+
+Note: More information about `Set-cookie` header is available in
+the [MDN web docs][set-cookie web doc].
+
+## What does the rule check?
+
+* `Secure` and `HttpOnly` cookies:
+
+  * `Secure` and `HttpOnly` directives **should** be present if sites are secure.
+  * `Secure` directive **should not** be present if sites are insecure.
+
+* Cookie prefixes:
+
+  * `__Secure-` and `__Host-` prefixes **can** be used only if sites are secure.
+  * Cookies with the `__Host-` prefix **should** have a `path` of "/"
+  (the entire host) and **should not** have a `domain` attribute.
+
+    Read more: [cookie prefixes][cookie prefixes].
+
+* Syntax validation:
+  * Validate cookie name and value string.
+  * Validate `Expires` value date format.
+
+* Browser compatibility of `Max-Age` directive:
+  * Some browsers (ie6, ie7, and ie8) doesn't support `Max-Age`.
+
+### Examples that **trigger** the rule
+
+`Set-Cookie` header that doesn't have a name-value string:
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: Max-Age=0; Secure; HttpOnly
+```
+
+`Set-Cookie` header that doesn't have the `Secure` directive:
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: cookieName=cookieValue; HttpOnly
+```
+
+`Set-Cookie` header that doesn't have the `HttpOnly` directive:
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: cookieName=cookieValue; Secure
+```
+
+`Set-Cookie` header that has invalid `name` or `value` string:
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: "cookieName"=cookieValue; Secure; HttpOnly
+```
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: cookieName=cookie value; Secure; HttpOnly
+```
+
+`Set-Cookie` header that has prefixes in the cookie name but is sent from pages
+using `http` protocol:
+
+From an insecure origin (HTTP):
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: __Secure-ID=123; Secure; Domain=example.com
+```
+
+`Set-Cookie` header that has `__Host-` prefix in the cookie name but has `Path`
+absent or `Domain` defined:
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: __Host-id=1; Secure
+```
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: __Host-id=1; Secure; Path=/; domain=example.com
+```
+
+### Examples that **pass** the rule
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: cookieName=cookieValue; Secure; HttpOnly
+```
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: cookieName="cookieValue"; Secure; HttpOnly
+```
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: __Host-ID=123; Secure; Path=/; HttpOnly
+```
+
+```text
+HTTP/... 200 OK
+
+...
+Set-Cookie: __Secure-ID=123; Secure; Domain=example.com; HttpOnly
+```
+
+[set-cookie web doc]:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+[xss]:https://developer.mozilla.org/en-US/docs/Glossary/Cross-site_scripting
+[cookie theft]:https://en.wikipedia.org/wiki/HTTP_cookie#Cross-site_scripting:_cookie_theft
+[proxy request]:https://en.wikipedia.org/wiki/HTTP_cookie#Cross-site_scripting:_proxy_request
+[http cookie wiki]:https://en.wikipedia.org/wiki/HTTP_cookie
+[HTTP State Management Mechanism]:https://tools.ietf.org/html/rfc6265
+[cookie prefixes]:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Cookie_prefixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "babel-plugin-transform-async-to-generator": "6.24.1",
         "babel-plugin-transform-es2015-destructuring": "6.23.0",
         "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
         "babel-plugin-transform-es2015-parameters": "6.24.1",
         "babel-plugin-transform-es2015-spread": "6.22.0",
         "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
@@ -93,9 +93,9 @@
       "dev": true
     },
     "@types/core-js": {
-      "version": "0.9.42",
-      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.42.tgz",
-      "integrity": "sha512-AiEZz42jF2f4nkcJ2OhKWxIbXU62pEHmFoaGoGo83seUzDEncxEZtBPX2i2DLUpcVpaVVxAsqAAZzTyrV0A/RQ=="
+      "version": "0.9.43",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.43.tgz",
+      "integrity": "sha512-Y11dktBJ5YwKXX8DfHSb9V6shXKSHN5P2URPZLHTRjX3OsO/u8u1kZnSJvsuSH74aTg8f5ZKcpEeCdIJOcBkHg=="
     },
     "@types/debug": {
       "version": "0.0.30",
@@ -1076,44 +1076,14 @@
       }
     },
     "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
+        "babel-runtime": "6.25.0",
+        "babel-types": "6.25.0",
         "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.0",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
-        }
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -1233,126 +1203,15 @@
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
-      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
       "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.0",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.8",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
+        "babel-runtime": "6.25.0",
+        "babel-template": "6.25.0",
+        "babel-types": "6.25.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -1384,7 +1243,7 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
+        "babel-helper-regex": "6.24.1",
         "babel-runtime": "6.25.0",
         "babel-types": "6.25.0"
       }
@@ -1395,7 +1254,7 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
+        "babel-helper-regex": "6.24.1",
         "babel-runtime": "6.25.0",
         "regexpu-core": "2.0.0"
       }
@@ -2038,7 +1897,7 @@
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.6.0.tgz",
       "integrity": "sha512-+KUHc73ov3QQMFbcd6BdIzoe9+8SAJQBOlNIfWighfO7Io9+B0ERxQ9qPdHUGG8JYya+WXqPWdZD6JOI3xkDcA==",
       "requires": {
-        "@types/core-js": "0.9.42",
+        "@types/core-js": "0.9.43",
         "@types/mkdirp": "0.3.29",
         "@types/node": "6.0.66",
         "@types/rimraf": "0.0.28",
@@ -2161,9 +2020,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "2.1.0",
@@ -3864,7 +3723,7 @@
         "ansi-escapes": "2.0.0",
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "external-editor": "2.0.4",
         "figures": "2.0.0",
         "lodash": "4.17.4",
@@ -5284,7 +5143,8 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
           "requires": {
             "kind-of": "3.2.2",
@@ -5294,22 +5154,26 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
@@ -5317,12 +5181,14 @@
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
             "arr-flatten": "1.1.0"
@@ -5330,27 +5196,32 @@
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+          "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.22.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -5360,7 +5231,8 @@
         },
         "babel-generator": {
           "version": "6.25.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+          "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
           "dev": true,
           "requires": {
             "babel-messages": "6.23.0",
@@ -5375,7 +5247,8 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0"
@@ -5383,7 +5256,8 @@
         },
         "babel-runtime": {
           "version": "6.23.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
           "dev": true,
           "requires": {
             "core-js": "2.4.1",
@@ -5392,7 +5266,8 @@
         },
         "babel-template": {
           "version": "6.25.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+          "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0",
@@ -5404,7 +5279,8 @@
         },
         "babel-traverse": {
           "version": "6.25.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+          "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
           "dev": true,
           "requires": {
             "babel-code-frame": "6.22.0",
@@ -5420,7 +5296,8 @@
         },
         "babel-types": {
           "version": "6.25.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+          "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0",
@@ -5431,17 +5308,20 @@
         },
         "babylon": {
           "version": "6.17.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
+          "integrity": "sha1-Pot0AriNIsNCPhN6FXeIOxX/hpo=",
           "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+          "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
@@ -5450,7 +5330,8 @@
         },
         "braces": {
           "version": "1.8.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
             "expand-range": "1.8.2",
@@ -5460,12 +5341,14 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
@@ -5475,13 +5358,15 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5491,7 +5376,8 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
@@ -5503,7 +5389,8 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -5514,7 +5401,8 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "dev": true,
               "optional": true
             }
@@ -5522,32 +5410,38 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
+          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
           "dev": true
         },
         "core-js": {
           "version": "2.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
             "lru-cache": "4.1.1",
@@ -5556,7 +5450,8 @@
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -5564,17 +5459,20 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
@@ -5582,7 +5480,8 @@
         },
         "detect-indent": {
           "version": "4.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
             "repeating": "2.0.1"
@@ -5590,7 +5489,8 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -5598,17 +5498,20 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -5622,7 +5525,8 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
             "is-posix-bracket": "0.1.1"
@@ -5630,7 +5534,8 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
             "fill-range": "2.2.3"
@@ -5638,7 +5543,8 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -5646,12 +5552,14 @@
         },
         "filename-regex": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
             "is-number": "2.1.0",
@@ -5663,7 +5571,8 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -5673,7 +5582,8 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
             "locate-path": "2.0.0"
@@ -5681,12 +5591,14 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
             "for-in": "1.0.2"
@@ -5694,7 +5606,8 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -5703,17 +5616,20 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
             "object-assign": "4.1.1",
@@ -5722,7 +5638,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5735,7 +5652,8 @@
         },
         "glob-base": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
             "glob-parent": "2.0.0",
@@ -5744,7 +5662,8 @@
         },
         "glob-parent": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
             "is-glob": "2.0.1"
@@ -5752,17 +5671,20 @@
         },
         "globals": {
           "version": "9.18.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "handlebars": {
           "version": "4.0.10",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
           "dev": true,
           "requires": {
             "async": "1.5.2",
@@ -5773,7 +5695,8 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -5783,7 +5706,8 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -5791,22 +5715,26 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "hosted-git-info": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -5815,12 +5743,14 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
@@ -5828,22 +5758,26 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
@@ -5851,12 +5785,14 @@
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
             "is-primitive": "2.0.0"
@@ -5864,17 +5800,20 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5882,7 +5821,8 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -5890,7 +5830,8 @@
         },
         "is-glob": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -5898,7 +5839,8 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -5906,37 +5848,44 @@
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true,
           "requires": {
             "isarray": "1.0.0"
@@ -5944,12 +5893,14 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
+          "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo=",
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+          "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
           "dev": true,
           "requires": {
             "append-transform": "0.4.0"
@@ -5957,7 +5908,8 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
+          "integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
           "dev": true,
           "requires": {
             "babel-generator": "6.25.0",
@@ -5971,7 +5923,8 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+          "integrity": "sha1-8OVfVmVf+jQiIIC3oM1HYOFAX8k=",
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.1.1",
@@ -5982,7 +5935,8 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
@@ -5992,7 +5946,8 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+          "integrity": "sha1-pv4ay6jOCO68Y45XLilNJnAIqgw=",
           "dev": true,
           "requires": {
             "debug": "2.6.8",
@@ -6004,7 +5959,8 @@
         },
         "istanbul-reports": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+          "integrity": "sha1-BCvlyJ4XW8P4ZSPKqynAFOd/7k4=",
           "dev": true,
           "requires": {
             "handlebars": "4.0.10"
@@ -6012,17 +5968,20 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
             "is-buffer": "1.1.5"
@@ -6030,13 +5989,15 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
@@ -6044,7 +6005,8 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6056,7 +6018,8 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
             "p-locate": "2.0.0",
@@ -6065,24 +6028,28 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
             "js-tokens": "3.0.2"
@@ -6090,7 +6057,8 @@
         },
         "lru-cache": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -6099,7 +6067,8 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -6107,12 +6076,14 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
             "mimic-fn": "1.1.0"
@@ -6120,7 +6091,8 @@
         },
         "merge-source-map": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+          "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
           "dev": true,
           "requires": {
             "source-map": "0.5.6"
@@ -6128,7 +6100,8 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
             "arr-diff": "2.0.0",
@@ -6148,12 +6121,14 @@
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.8"
@@ -6161,12 +6136,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -6174,12 +6151,14 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
           "dev": true,
           "requires": {
             "hosted-git-info": "2.5.0",
@@ -6190,7 +6169,8 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
             "remove-trailing-separator": "1.0.2"
@@ -6198,7 +6178,8 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -6206,17 +6187,20 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
             "for-own": "0.1.5",
@@ -6225,7 +6209,8 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -6233,7 +6218,8 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8",
@@ -6242,12 +6228,14 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
+          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
           "dev": true,
           "requires": {
             "execa": "0.5.1",
@@ -6257,17 +6245,20 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
             "p-limit": "1.1.0"
@@ -6275,7 +6266,8 @@
         },
         "parse-glob": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
             "glob-base": "0.3.0",
@@ -6286,7 +6278,8 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
             "error-ex": "1.3.1"
@@ -6294,7 +6287,8 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
@@ -6302,22 +6296,26 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6327,17 +6325,20 @@
         },
         "pify": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
             "pinkie": "2.0.4"
@@ -6345,7 +6346,8 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
             "find-up": "1.1.2"
@@ -6353,7 +6355,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -6364,17 +6367,20 @@
         },
         "preserve": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
           "dev": true
         },
         "randomatic": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+          "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
           "dev": true,
           "requires": {
             "is-number": "3.0.0",
@@ -6383,7 +6389,8 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
                 "kind-of": "3.2.2"
@@ -6391,7 +6398,8 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
                     "is-buffer": "1.1.5"
@@ -6401,7 +6409,8 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
                 "is-buffer": "1.1.5"
@@ -6411,7 +6420,8 @@
         },
         "read-pkg": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
@@ -6421,7 +6431,8 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
             "find-up": "1.1.2",
@@ -6430,7 +6441,8 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -6441,12 +6453,14 @@
         },
         "regenerator-runtime": {
           "version": "0.10.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
           "dev": true,
           "requires": {
             "is-equal-shallow": "0.1.3",
@@ -6455,22 +6469,26 @@
         },
         "remove-trailing-separator": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
+          "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
             "is-finite": "1.0.2"
@@ -6478,22 +6496,26 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6502,7 +6524,8 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -6510,32 +6533,38 @@
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.3.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.8.tgz",
+          "integrity": "sha1-+ip5uZDLsLsAGNymdI2INnsZ7DE=",
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -6548,7 +6577,8 @@
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
           "dev": true,
           "requires": {
             "spdx-license-ids": "1.2.2"
@@ -6556,17 +6586,20 @@
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -6575,17 +6608,20 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
@@ -6595,7 +6631,8 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -6603,7 +6640,8 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
@@ -6611,17 +6649,20 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
+          "integrity": "sha1-TYSWSwlmsAh+zDNKLOAC09k0HiY=",
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -6633,17 +6674,20 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
           "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -6654,7 +6698,8 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -6668,13 +6713,15 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.2",
@@ -6683,7 +6730,8 @@
         },
         "which": {
           "version": "1.2.14",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -6691,23 +6739,27 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -6716,7 +6768,8 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -6728,12 +6781,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -6743,17 +6798,20 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         },
         "yargs": {
           "version": "8.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
             "camelcase": "4.1.0",
@@ -6773,12 +6831,14 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
                 "string-width": "1.0.2",
@@ -6788,7 +6848,8 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                   "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
@@ -6800,7 +6861,8 @@
             },
             "load-json-file": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -6811,7 +6873,8 @@
             },
             "path-type": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
               "dev": true,
               "requires": {
                 "pify": "2.3.0"
@@ -6819,7 +6882,8 @@
             },
             "read-pkg": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
               "dev": true,
               "requires": {
                 "load-json-file": "2.0.0",
@@ -6829,7 +6893,8 @@
             },
             "read-pkg-up": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
               "dev": true,
               "requires": {
                 "find-up": "2.1.0",
@@ -6838,12 +6903,14 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
               "dev": true
             },
             "yargs-parser": {
               "version": "7.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
@@ -6853,7 +6920,8 @@
         },
         "yargs-parser": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "dev": true,
           "requires": {
             "camelcase": "3.0.0"
@@ -6861,7 +6929,8 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
               "dev": true
             }
           }

--- a/src/lib/rules/validate-set-cookie-header/validate-set-cookie-header.ts
+++ b/src/lib/rules/validate-set-cookie-header/validate-set-cookie-header.ts
@@ -1,0 +1,316 @@
+/**
+ * @fileoverview This rule validates the `set-cookie` header and confirms that it is sent with `Secure` and `HttpOnly` directive over HTTPS.
+ */
+
+import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
+import { debug as d } from '../../utils/debug';
+import { IFetchEnd, IAsyncHTMLElement, IResponse, IRuleBuilder, IRule, ParsedSetCookieHeader, Severity } from '../../types'; // eslint-disable-line no-unused-vars
+import { isHTTPS, isRegularProtocol, normalizeString } from '../../utils/misc';
+
+const debug = d(__filename);
+
+// ------------------------------------------------------------------------------
+// Public
+// ------------------------------------------------------------------------------
+
+const rule: IRuleBuilder = {
+    create(context: RuleContext): IRule {
+        /** If targetBrowsers contain ie 6, ie 7 or ie 8 */
+        let supportOlderBrowsers: boolean;
+        /** A collection of accepted attributes
+         * See https://stackoverflow.com/questions/19792038/what-does-priority-high-mean-in-the-set-cookie-header for details about the `priority` attribute.
+        */
+        const acceptedCookieAttributes: Array<string> = ['expires', 'max-age', 'domain', 'path', 'secure', 'httponly', 'samesite', 'priority'];
+        /** A collection of illegal characters in cookie name
+         * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
+        */
+        const illegalCookieNameChars: string = '()<>@,;:\"/[]?={}'; // eslint-disable-line no-useless-escape
+        /** A collection of illegal characters in cookie value
+         * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
+         */
+        const illegalCookieValueChars: string = ',;"/';
+        /** Header name used in report */
+        const headerName: string = 'set-cookie';
+
+        type ValidationMessages = Array<string>;
+        type Validator = (parsedSetCookie: ParsedSetCookieHeader) => ValidationMessages; // eslint-disable-line no-unused-vars
+
+        /** Trim double quote from the value string. */
+        const unquote = (value: string): string => {
+            return value.replace(/(^")|("$)/g, '');
+        };
+
+        /** Normalize the string before the first `=`, concat and unquote the strings after the first `=`. */
+        const normalizeAfterSplitByEqual = (splitResult: Array<string>): Array<string> => {
+            const [key, ...value]: Array<string> = splitResult;
+
+            return [normalizeString(key), unquote(value.join('='))];
+        };
+
+        /** `Set-Cookie` header parser based on the algorithm used by a user agent defined in the spec:
+        https://tools.ietf.org/html/rfc6265#section-5.2.1 */
+        const parse = (setCookieValue: string): ParsedSetCookieHeader => {
+            const [nameValuePair, ...directivePairs]: Array<string> = setCookieValue.split(';');
+            const [cookieName, cookieValue]: Array<string> = normalizeAfterSplitByEqual(nameValuePair.split('='));
+
+            const setCookie: ParsedSetCookieHeader = {
+                name: cookieName,
+                value: cookieValue
+            };
+
+            if (directivePairs[directivePairs.length - 1] === '') {
+                throw new Error(`'${headerName}' header to set '${setCookie.name}' has trailing ';'`);
+            }
+
+            directivePairs.forEach((part) => {
+                const [directiveKey, directiveValue] = normalizeAfterSplitByEqual(part.split('='));
+
+                if (!acceptedCookieAttributes.includes(directiveKey)) {
+                    throw new Error(`'${headerName}' header contains unknown attribute '${directiveKey}'.`);
+                }
+
+                if (setCookie[directiveKey]) {
+                    throw new Error(`'${headerName}' header contains more than one ${directiveKey}.`);
+                }
+
+                setCookie[directiveKey] = directiveValue || true;
+
+            });
+
+            return setCookie;
+        };
+
+        const validASCII = (string: string): Boolean => {
+            return (/^[\x00-\x7F]+$/).test(string); // eslint-disable-line no-control-regex
+        };
+
+        /** Validate cookie name or value string.
+        Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie */
+        const validString = (name: string, illegalChars: string): Boolean => {
+            const includesIllegalChars: boolean = illegalChars.split('').some((char) => {
+                return name.includes(char);
+            });
+            const includesWhiteSpace: boolean = (/\s/g).test(name);
+
+            return validASCII(name) && !includesIllegalChars && !includesWhiteSpace;
+        };
+
+        /** Validate cookie name-value string. */
+        const validateNameAndValue = (parsedSetCookie: ParsedSetCookieHeader): ValidationMessages => {
+            const cookieName: string = parsedSetCookie.name;
+            const errors: ValidationMessages = [];
+
+            const noNameValueStringError: string = `'${headerName}' header doesn't contain a cookie name-value string.`;
+            const invalidNameError: string = `'${headerName}' header to set '${cookieName}' has an invalid cookie name.`;
+            const invalidValueError: string = `'${headerName}' header to set '${cookieName}' has an invalid cookie value.`;
+
+            // Check name-value-string exists and it is before the first `;`.
+            if (!cookieName || acceptedCookieAttributes.includes(cookieName)) {
+                errors.push(noNameValueStringError);
+
+                return errors;
+            }
+
+            // Validate cookie name.
+            if (!validString(cookieName, illegalCookieNameChars)) {
+                errors.push(invalidNameError);
+            }
+
+            // Validate cookie value.
+            if (!validString(parsedSetCookie.value, illegalCookieValueChars)) {
+                errors.push(invalidValueError);
+            }
+
+            return errors;
+        };
+
+        /** Validate cookie name prefixes. */
+        const validatePrefixes = (parsedSetCookie: ParsedSetCookieHeader): ValidationMessages => {
+            const cookieName: string = parsedSetCookie.name;
+            const resource: string = parsedSetCookie.resource;
+            const errors: ValidationMessages = [];
+
+            const hasPrefixHttpError: string = `'${headerName}' header contains prefixes but is from an insecure page.`;
+            const noPathHasHostPrefixError: string = `${headerName} header contains '__Host-' prefix but the 'path' directive doesn't have a value of '/'.`;
+            const hasDomainHostPrefixError: string = `${headerName} header contains '__Host-' prefix but the 'domain' directive is set.`;
+
+            if ((cookieName.startsWith('__secure-') || cookieName.startsWith('__host-')) && !isHTTPS(resource)) {
+                errors.push(hasPrefixHttpError);
+            }
+
+            if (cookieName.startsWith('__host-')) {
+                if (!parsedSetCookie.path || parsedSetCookie.path !== '/') {
+                    errors.push(noPathHasHostPrefixError);
+                }
+
+                if (parsedSetCookie.domain) {
+                    errors.push(hasDomainHostPrefixError);
+                }
+            }
+
+            return errors;
+        };
+
+        /** Validate `Secure` and `HttpOnly` attributes. */
+        const validateSecurityAttributes = (parsedSetCookie: ParsedSetCookieHeader): ValidationMessages => {
+            const cookieName: string = parsedSetCookie.name;
+            const resource: string = parsedSetCookie.resource;
+            const errors: ValidationMessages = [];
+
+            const hasSecureHttpError: string = `Insecure sites (${resource}) can't set cookies with the 'secure' directive.`;
+            const noSecureError: string = `'${headerName}' header to set '${cookieName}' doesn't have the 'secure' directive.`;
+            const noHttpOnlyError: string = `'${headerName}' header to set '${cookieName}' doesn't have the 'httponly' directive.`;
+
+            // Check against `Secure` directive if sites are insecure.
+            if (!isHTTPS(resource) && parsedSetCookie.secure) {
+                errors.push(hasSecureHttpError);
+
+                return errors;
+            }
+
+            // Check for `Secure` directive if sites are secure.
+            if (!parsedSetCookie.secure) {
+                errors.push(noSecureError);
+            }
+
+            // Check for `httpOnly` directive.
+            if (!parsedSetCookie.httponly) {
+                errors.push(noHttpOnlyError);
+            }
+
+            return errors;
+        };
+
+        /** Validate `Expire` date format. */
+        const validateExpireDate = (parsedSetCookie: ParsedSetCookieHeader): ValidationMessages => {
+            const cookieName: string = parsedSetCookie.name;
+            const errors: ValidationMessages = [];
+
+            if (!parsedSetCookie.expires) {
+                return errors;
+            }
+
+            // Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+            const utcTimeString: string = new Date(parsedSetCookie.expires).toUTCString();
+            const invalidDateError: string = `Invalid date in 'expires' value of the '${headerName}' header to set '${cookieName}'.`;
+            const invalidDateFormatError: string = `Invalid date format in 'expires' value of the '${headerName}' header to set '${cookieName}'. The recommended format is: ${utcTimeString}`;
+
+            if (utcTimeString === 'Invalid Date') {
+                errors.push(invalidDateError);
+
+                return errors;
+            }
+
+            if (normalizeString(utcTimeString) !== normalizeString(parsedSetCookie.expires)) {
+                errors.push(invalidDateFormatError);
+            }
+
+            return errors;
+        };
+
+        /** Validate the usage of `Max-Age` and `Expires` based on users' browser support matrix */
+        const validateMaxAgeAndExpires = (parsedSetCookie: ParsedSetCookieHeader): ValidationMessages => {
+            const cookieName: string = parsedSetCookie.name;
+            const errors: ValidationMessages = [];
+            const maxAgeCompatibilityMessage: string = `Internet Explorer (IE 6, IE 7, and IE 8) doesn't support 'max-age' directive in the '${headerName}' header to set '${cookieName}'.`;
+            const maxAgeAndExpireDuplicateMessage: string = `The 'max-age' attribute takes precedence when both 'expires' and 'max-age' both exist.`;
+
+            if (supportOlderBrowsers) {
+                // When targetBrowsers contains IE 6, IE 7 or IE 8:
+                // `max-age` can't be used alone.
+                if (parsedSetCookie['max-age'] && !parsedSetCookie.expires) {
+                    errors.push(maxAgeCompatibilityMessage);
+                }
+
+                return errors;
+            }
+
+            // When targetBrowsers only contains modern browsers:
+            // `max-age` takes precedence so `expires` shouldn't be used.
+            // Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives
+            if (parsedSetCookie['max-age'] && parsedSetCookie.expires) {
+                errors.push(maxAgeAndExpireDuplicateMessage);
+            }
+
+            return errors;
+        };
+
+        const loadRuleConfigs = () => {
+            supportOlderBrowsers = ['ie 6', 'ie 7', 'ie 8'].some((e) => {
+                return context.targetedBrowsers.includes(e);
+            });
+        };
+
+        const validate = async (fetchEnd: IFetchEnd) => {
+            const { element, resource, response }: { element: IAsyncHTMLElement, resource: string, response: IResponse } = fetchEnd;
+            const defaultValidators: Array<Validator> = [validateNameAndValue, validatePrefixes, validateSecurityAttributes, validateExpireDate, validateMaxAgeAndExpires];
+
+            // This check does not apply if URI starts with protocols others than http/https.
+            if (!isRegularProtocol(resource)) {
+                debug(`Check does not apply for URI: ${resource}`);
+
+                return;
+            }
+
+            const rawSetCookieHeaders: string | Array<string> = response.headers && response.headers['set-cookie'];
+
+            if (!rawSetCookieHeaders) {
+                return;
+            }
+
+            /**  The `cdp` connector concatenates all `set-cookie` headers to one string. */
+            const setCookieHeaders: Array<string> = Array.isArray(rawSetCookieHeaders) ? rawSetCookieHeaders : rawSetCookieHeaders.split(/\n|\r\n/);
+            const reportBatch = async (errorMessages: ValidationMessages, severity?: Severity): Promise<void[]> => {
+                const promises: Array<Promise<void>> = errorMessages.map((error) => {
+                    return context.report(resource, element, error, null, null, severity);
+                });
+
+                return await Promise.all(promises);
+            };
+
+            for (const setCookieHeader of setCookieHeaders) {
+                let parsedSetCookie: ParsedSetCookieHeader;
+
+                try {
+                    parsedSetCookie = parse(setCookieHeader);
+                    parsedSetCookie.resource = resource;
+                } catch (err) {
+                    await context.report(resource, element, err.message);
+
+                    return;
+                }
+
+                for (const defaultValidator of defaultValidators) {
+                    const messages: ValidationMessages = defaultValidator(parsedSetCookie);
+
+                    if (messages.length) {
+                        await reportBatch(messages);
+
+                        return;
+                    }
+                }
+            }
+        };
+
+        loadRuleConfigs();
+
+        return {
+            'fetch::end': validate,
+            'manifestfetch::end': validate,
+            'targetfetch::end': validate
+        };
+    },
+    meta: {
+        docs: {
+            category: 'Security',
+            description: 'This rule validates the `set-cookie` header and confirms that it is sent with `Secure` and `HttpOnly` directive over HTTPS.'
+        },
+        fixable: 'code',
+        ignoredConnectors: [],
+        recommended: true,
+        schema: [],
+        worksWithLocalFiles: false
+    }
+};
+
+module.exports = rule;

--- a/src/lib/types/rules.ts
+++ b/src/lib/types/rules.ts
@@ -47,3 +47,17 @@ export type SSLLabsEndpoint = {
 export type SSLLabsResult = {
     endpoints: Array<SSLLabsEndpoint>;
 };
+
+/** Parsed Set Cookie Header */
+export type ParsedSetCookieHeader = {
+    domain?: string;
+    expires?: string;
+    httponly?: boolean;
+    'max-age'?: string;
+    name: string;
+    path?: string;
+    resource?: string;
+    samesite?: boolean;
+    secure?: boolean;
+    value: string;
+};

--- a/tests/helpers/rule-runner.ts
+++ b/tests/helpers/rule-runner.ts
@@ -158,7 +158,15 @@ export const testRule = (ruleId: string, ruleTests: Array<IRuleTest>, configs: {
 
         if (!rule.meta.ignoredConnectors || !rule.meta.ignoredConnectors.includes(connector)) {
             ruleTests.forEach((ruleTest) => {
-                const runner = configs['serial'] ? test.serial : test; // eslint-disable-line dot-notation
+                let runner;
+
+                runner = configs['serial'] ? test.serial : test; // eslint-disable-line dot-notation
+
+                // If the tests for a rule ignores the connector, then we
+                // skip the tests
+                if (configs.ignoredConnectors && configs.ignoredConnectors.includes(connector)) {
+                    runner = test.skip;
+                }
 
                 runner(`[${connector}]${ruleTest.name}`, runRule, ruleTest, connector);
             });

--- a/tests/lib/rules/validate-set-cookie-header/tests.ts
+++ b/tests/lib/rules/validate-set-cookie-header/tests.ts
@@ -1,0 +1,230 @@
+/* eslint sort-keys: 0, no-undefined: 0 */
+
+import { IRuleTest } from '../../../helpers/rule-test-type'; // eslint-disable-line no-unused-vars
+import * as ruleRunner from '../../../helpers/rule-runner';
+import { getRuleName } from '../../../../src/lib/utils/rule-helpers';
+const ruleName = getRuleName(__dirname);
+
+// Headers.
+const setCookie = (fields) => {
+    return { 'set-cookie': fields };
+};
+
+// Headers that will pass.
+const doubleQuotedValueHeader = setCookie(`cookieName="cookieValue"; Secure; HttpOnly`);
+const standardHeader = setCookie(`cookieName=cookieValue; Secure; HttpOnly`);
+const starnderHeaderLowerCase = setCookie(`cookieName=cookieValue; secure; httponly`);
+const standardHeaderWithSecurePrefix = setCookie(`__Secure-ID=123; Secure; Domain=example.com; HttpOnly`);
+const standardHeaderWithHostPrefix = setCookie(`__Host-ID=123; Secure; Path=/; HttpOnly`);
+
+// Headers that will fail.
+const noNameValueStringHeader = setCookie(`Max-Age=0; Secure; HttpOnly`);
+const invalidAttributeHeader = setCookie(`cookieName=cookieValue; MaxAge=0; Secure; HttpOnly`);
+const noSecureHeader = setCookie(`cookieName=cookieValue; HttpOnly`);
+const noHttpOnlyHeader = setCookie(`cookieName=cookieValue; Secure`);
+
+const invalidNameHeader = setCookie(`"cookieName"=cookieValue; Secure; HttpOnly`);
+const invalidValueHeader = setCookie(`cookieName=cookie value; Secure; HttpOnly`);
+const invalidDateFormatHeader = setCookie(`cookieName=cookieValue; expires=Wed, 31-Dec-97 23:59:59 GMT; Secure; HttpOnly`);
+const trailingSemicolonHeader = setCookie(`cookieName=cookieValue;`);
+const multipleErrorsHeader = setCookie(`"cookieName"=cookie value`);
+
+const noPathHostPrefixHeader = setCookie(`__Host-id=1; Secure; HttpOnly`);
+const hasDomainHostPrefixHeader = setCookie(`__Host-id=1; Secure; Path=/; domain=example.com; HttpOnly`);
+
+const maxAgeOnlyHeader = setCookie(`cookieName=cookieValue; Max-Age=123; secure; httponly`);
+const expiresOnlyHeader = setCookie(`cookieName=cookieValue; expires=Wed, 21 Oct 2015 07:28:00 GMT; secure; httponly`);
+const bothMaxAgeAndExpireHeader = setCookie(`cookieName=cookieValue; Max-Age=123; expires=Wed, 21 Oct 2015 07:28:00 GMT; secure; httponly`);
+
+// Error messages.
+const messages = (cookieName: string = 'cookiename'): { [key: string]: string } => {
+    return {
+        hasDomainHostPrefixError: `set-cookie header contains '__Host-' prefix but the 'domain' directive is set.`,
+        invalidAttributeError: `'set-cookie' header contains unknown attribute 'maxage'.`,
+        invalidDateFormatError: `Invalid date format in 'expires' value of the 'set-cookie' header to set '${cookieName}'. The recommended format is: Wed, 31 Dec 1997 23:59:59 GMT`,
+        invalidNameError: `'set-cookie' header to set '${cookieName}' has an invalid cookie name.`,
+        invalidValueError: `'set-cookie' header to set '${cookieName}' has an invalid cookie value.`,
+        noHttpOnlyHeaderError: `'set-cookie' header to set '${cookieName}' doesn't have the 'httponly' directive.`,
+        noNameValueStringError: `'set-cookie' header doesn't contain a cookie name-value string.`,
+        noPathHasHostPrefixError: `set-cookie header contains '__Host-' prefix but the 'path' directive doesn't have a value of '/'.`,
+        noSecureHeaderError: `'set-cookie' header to set '${cookieName}' doesn't have the 'secure' directive.`,
+        maxAgeNoExpireWarning: `Internet Explorer (IE 6, IE 7, and IE 8) doesn't support 'max-age' directive in the 'set-cookie' header to set 'cookiename'.`,
+        maxAgePrecedenceWarning: `The 'max-age' attribute takes precedence when both 'expires' and 'max-age' both exist.`,
+        trailingSemicolonError: `'set-cookie' header to set '${cookieName}' has trailing ';'`
+    };
+};
+
+const defaultTests: Array<IRuleTest> = [
+    {
+        name: `Standard set-cookie header`,
+        serverConfig: { '/': { headers: standardHeader } }
+    },
+    {
+        name: `Cooke value is wrapped in double quotes`,
+        serverConfig: { '/': { headers: doubleQuotedValueHeader } }
+    },
+    {
+        name: `Directive names are in lowercases`,
+        serverConfig: { '/': { headers: starnderHeaderLowerCase } }
+    },
+    {
+        name: `Standard set-cookie header with '__secure' prefix`,
+        serverConfig: { '/': { headers: standardHeaderWithSecurePrefix } }
+    },
+    {
+        name: `Standard set-cookie header with '__Host' prefix`,
+        serverConfig: { '/': { headers: standardHeaderWithHostPrefix } }
+    },
+    {
+        name: `Header doesn't have cookie name-value-string`,
+        serverConfig: { '/': { headers: noNameValueStringHeader } },
+        reports: [{ message: messages().noNameValueStringError }]
+    },
+    {
+        name: `Header contains unknown attributes`,
+        serverConfig: { '/': { headers: invalidAttributeHeader } },
+        reports: [{ message: messages().invalidAttributeError }]
+    },
+    {
+        name: `Header doesn't have 'Secure' directive`,
+        serverConfig: { '/': { headers: noSecureHeader } },
+        reports: [{ message: messages().noSecureHeaderError }]
+    },
+    {
+        name: `Header doesn't have 'HttpOnly' directive`,
+        serverConfig: { '/': { headers: noHttpOnlyHeader } },
+        reports: [{ message: messages().noHttpOnlyHeaderError }]
+    },
+    {
+        name: `Cookie name contains invalid characters`,
+        serverConfig: { '/': { headers: invalidNameHeader } },
+        reports: [{ message: messages('"cookiename"').invalidNameError }]
+    },
+    {
+        name: `Cookie value contains invalid characters`,
+        serverConfig: { '/': { headers: invalidValueHeader } },
+        reports: [{ message: messages().invalidValueError }]
+    },
+    {
+        name: `'Expires' directive contains invalid date format`,
+        serverConfig: { '/': { headers: invalidDateFormatHeader } },
+        reports: [{ message: messages().invalidDateFormatError }]
+    },
+    {
+        name: `Header contains trailing semicolon`,
+        serverConfig: { '/': { headers: trailingSemicolonHeader } },
+        reports: [{ message: messages().trailingSemicolonError }]
+    },
+    {
+        name: `Header contains multiple errors`,
+        serverConfig: { '/': { headers: multipleErrorsHeader } },
+        reports: [
+            { message: messages('"cookiename"').invalidNameError },
+            { message: messages('"cookiename"').invalidValueError }
+        ]
+    },
+    {
+        name: `Cookie name has '__Host' prefix but doesn't have 'Path' directive`,
+        serverConfig: { '/': { headers: noPathHostPrefixHeader } },
+        reports: [{ message: messages().noPathHasHostPrefixError }]
+    },
+    {
+        name: `Cookie name has '__Host' prefix but has 'Domain' directive set`,
+        serverConfig: { '/': { headers: hasDomainHostPrefixHeader } },
+        reports: [{ message: messages().hasDomainHostPrefixError }]
+    }
+];
+
+const olderBrowserOnlyTests = [
+    {
+        name: `'Max-Age' only in old browsers`,
+        serverConfig: { '/': { headers: maxAgeOnlyHeader } },
+        reports: [{ message: messages().maxAgeNoExpireWarning }]
+    },
+    {
+        name: `Both 'Max-Age' and 'Expires' exist in new browsers`,
+        serverConfig: { '/': { headers: bothMaxAgeAndExpireHeader } }
+    },
+    {
+        name: `'Expires' only in new browsers`,
+        serverConfig: { '/': { headers: expiresOnlyHeader } }
+    },
+    {
+        name: `No 'Max-Age' or 'Expires' in new browsers`,
+        serverConfig: { '/': { headers: standardHeader } }
+    }
+];
+
+const newBrowserOnlyTests = [
+    {
+        name: `Both 'Max-Age' and 'Expires' exist in new browsers`,
+        serverConfig: { '/': { headers: bothMaxAgeAndExpireHeader } },
+        reports: [{ message: messages().maxAgePrecedenceWarning }]
+    },
+    {
+        name: `'Max-Age' only in new browsers`,
+        serverConfig: { '/': { headers: maxAgeOnlyHeader } }
+    },
+    {
+        name: `'Expires' only in new browsers`,
+        serverConfig: { '/': { headers: expiresOnlyHeader } }
+    },
+    {
+        name: `No 'Max-Age' or 'Expires' in new browsers`,
+        serverConfig: { '/': { headers: standardHeader } }
+    }
+];
+
+const oldAndNewBrowsersTest = [
+    {
+        name: `'Max-Age' only in old browsers`,
+        serverConfig: { '/': { headers: maxAgeOnlyHeader } },
+        reports: [{ message: messages().maxAgeNoExpireWarning }]
+    },
+    {
+        name: `Both 'Max-Age' and 'Expires' exist in new browsers`,
+        serverConfig: { '/': { headers: bothMaxAgeAndExpireHeader } }
+    },
+    {
+        name: `'Expires' only in new browsers`,
+        serverConfig: { '/': { headers: expiresOnlyHeader } }
+    },
+    {
+        name: `No 'Max-Age' or 'Expires' in new browsers`,
+        serverConfig: { '/': { headers: standardHeader } }
+    }
+];
+
+ruleRunner.testRule(ruleName, defaultTests, {
+    https: true,
+    // Tests are skipped in `cdp` due to the absence of 'Set-Cookie' header.
+    // Issue: https://bugs.chromium.org/p/chromium/issues/detail?id=692090.
+    // TODO: Update the tests once the issue above is fixed.
+    ignoredConnectors: ['cdp']
+});
+
+ruleRunner.testRule(ruleName, newBrowserOnlyTests, {
+    browserslist: [
+        '> 1%',
+        'last 2 versions'
+    ],
+    https: true,
+    ignoredConnectors: ['cdp']
+});
+
+ruleRunner.testRule(ruleName, olderBrowserOnlyTests, {
+    browserslist: [
+        'ie 6', 'ie 7'
+    ],
+    https: true,
+    ignoredConnectors: ['cdp']
+});
+
+ruleRunner.testRule(ruleName, oldAndNewBrowsersTest, {
+    browserslist: [
+        'ie >= 6',
+        'last 2 versions'
+    ],
+    https: true,
+    ignoredConnectors: ['cdp']
+});


### PR DESCRIPTION
Fix #24 

Note: It's possible for one response to contain multiple `Set-Cookie` headers. The `cdp` connector concatenate all `Set-Cookie` headers into one single string (no delimiter to split it into an array). And `jsdom` returns an array containing all the `Set-Cookie` headers. So analyzing the `Set-Cookie` headers one by one seems impossible using the `cdp` connector.

The first commit is cherry picked from #370. So only commit 2 needs to be reviewed in this PR.