### PR TITLE
Fix: SyntaxError when using jsdom

### DIFF
--- a/src/lib/utils/location-helpers.ts
+++ b/src/lib/utils/location-helpers.ts
@@ -3,7 +3,11 @@ import { IAsyncHTMLAttribute, IAsyncHTMLElement, IProblemLocation } from './../t
 
 const debug: debug.IDebugger = d(__filename);
 
-const doubleQuotesRegex: RegExp = /"/g;
+const quotesRegex: RegExp = /('|")/g;
+
+const escapeQuotes = (text: string): string => {
+    return text.replace(quotesRegex, '\\$1');
+};
 
 /**
  * Creates a CSS selector from a given element using its attributes and the type of node:
@@ -19,7 +23,7 @@ const selectorFromElement = (element: IAsyncHTMLElement): string => {
     for (let i = 0; i < attributes.length; i++) {
         const attribute: IAsyncHTMLAttribute | NamedNodeMap = attributes[i];
 
-        selector += `[${attribute.name}="${attribute.value.replace(doubleQuotesRegex, '\\"')}"]`;
+        selector += `[${attribute.name}="${escapeQuotes(attribute.value)}"]`;
     }
 
     debug(`Selector created: ${selector}`);

--- a/tests/lib/rules/disown-opener/tests.ts
+++ b/tests/lib/rules/disown-opener/tests.ts
@@ -80,6 +80,11 @@ const testsForDefaults: Array<RuleTest> = [
         serverConfig: { '/': generateHTMLPage(undefined, `<a href="//example.com" target="_blank">test</a>`) }
     },
     {
+        name: `'a' with 'href="//example.com"' has 'target="_blank"' and single quotes in some attribute`,
+        reports: [{ message: generateMissingMessage(`<a href="//example.com" target="_blank" mouseover="return 'hello!';">test</a>`, ['noopener', 'noreferrer']) }],
+        serverConfig: { '/': generateHTMLPage(undefined, `<a href="//example.com" target="_blank" mouseover="return 'hello!';">test</a>`) }
+    },
+    {
         name: `'map' href="//example.com" has 'target="_blank"'`,
         reports: [{ message: generateMissingMessage('<area shape="rect" coords="0,0,100,100" href="//example.com" target="_blank" rel="nofollow">', ['noopener', 'noreferrer']) }],
         serverConfig: {


### PR DESCRIPTION
Escape character `'` in selectors in location-helpers.ts
Fix #404