### PR TITLE
Breaking: Change`highest-available-document-mode` rule removal suggestions

### DIFF
--- a/src/lib/rules/highest-available-document-mode/highest-available-document-mode.ts
+++ b/src/lib/rules/highest-available-document-mode/highest-available-document-mode.ts
@@ -156,12 +156,19 @@ const rule: IRuleBuilder = {
         const loadRuleConfigs = () => {
             requireMetaTag = (context.ruleOptions && context.ruleOptions.requireMetaTag) || false;
 
+            const targetedBrowsers: string[] = context.targetedBrowsers;
+
             // Document modes are only supported by Internet Explorer 8/9/10.
             // https://msdn.microsoft.com/en-us/library/jj676915.aspx
+            //
+            // If no browsers are targeted, assume Internet Explorer 8/9/10
+            // are supported.
 
-            suggestRemoval = ['ie 8', 'ie 9', 'ie 10'].some((e) => {
-                return context.targetedBrowsers.includes(e);
-            });
+            if (targetedBrowsers.length !== 0) {
+                suggestRemoval = !['ie 8', 'ie 9', 'ie 10'].some((e) => {
+                    return targetedBrowsers.includes(e);
+                });
+            }
         };
 
         const validate = async (event: ITraverseEnd) => {

--- a/tests/lib/rules/highest-available-document-mode/tests.ts
+++ b/tests/lib/rules/highest-available-document-mode/tests.ts
@@ -91,25 +91,46 @@ const testsForRequireMetaTagConfig: Array<IRuleTest> = [
     }
 ];
 
+const testsForHeaderWithBlankTargetBrowsersConfig: Array<IRuleTest> = [
+    {
+        name: `HTML page is served without the 'X-UA-Compatible' header, but it's required by the targeted browsers`,
+        reports: [{ message: `'x-ua-compatible' header was not specified` }],
+        serverConfig: { '/': '' }
+    }
+];
+
+const testsForMetaTagWithBlankTargetBrowsersConfig: Array<IRuleTest> = [
+    {
+        name: `'X-UA-Compatible' meta tag is not specified, but it's required by the targeted browsers`,
+        reports: [{ message: `No 'x-ua-compatible' meta tag was specified` }],
+        serverConfig: { '/': { headers: { 'X-UA-Compatible': 'ie=edge' } } }
+    }
+];
+
 const testsForTargetBrowsersConfig: Array<IRuleTest> = [
     {
-        name: `HTML page is served with 'X-UA-Compatible' header but the targeted browsers don't support document modes`,
-        reports: [{ message: `'x-ua-compatible' header is not needed` }],
-        serverConfig: { '/': { headers: { 'X-UA-Compatible': 'ie=edge' } } }
-    },
-    {
-        name: `'X-UA-Compatible' meta tag is not specified but the targeted browsers don't support document modes`,
-        reports: [{ message: `Meta tag is not needed` }],
-        serverConfig: { '/': { content: generateHTMLPageWithMetaTag() } }
+        name: `HTML page is served with both 'X-UA-Compatible' header and meta tag, but they are not required by the targeted browsers`,
+        reports: [
+            { message: `'x-ua-compatible' header is not needed` },
+            { message: `Meta tag is not needed` }
+        ],
+        serverConfig: {
+            '/': {
+                content: generateHTMLPageWithMetaTag(),
+                headers: { 'X-UA-Compatible': 'ie=edge' }
+            }
+        }
     }
 ];
 
 ruleRunner.testRule(ruleName, testsForDefaults);
 ruleRunner.testRule(ruleName, testsForRequireMetaTagConfig, { ruleOptions: { requireMetaTag: true } });
+ruleRunner.testRule(ruleName, testsForHeaderWithBlankTargetBrowsersConfig, { browserslist: [] });
+ruleRunner.testRule(ruleName, testsForMetaTagWithBlankTargetBrowsersConfig, {
+    browserslist: [],
+    ruleOptions: { requireMetaTag: true }
+});
 ruleRunner.testRule(ruleName, testsForTargetBrowsersConfig, {
-    browserslist: [
-        'ie >= 6',
-        'last 2 versions'
-    ],
+    browserslist: ['ie 11'],
     ruleOptions: { requireMetaTag: true }
 });


### PR DESCRIPTION
If no browsers are targeted (i.e. `browserlist` is empty), make `highest-available-document-mode` rule assume Internet Explorer 8, 9, and 10 are supported.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref #446
Fix #447