### PR TITLE
Chore: Fix lint script to actually ignore `dist/`

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "clean": "rimraf dist",
     "commitmsg": "node scripts/check-commit-message.js",
     "lint": "npm-run-all lint:*",
-    "lint:js": "eslint --ext md --ext ts --ignore-pattern dist/* .",
+    "lint:js": "eslint --ext md --ext ts --ignore-pattern dist .",
     "lint:md": "markdownlint ./.github docs",
     "preparecommitmsg": "node scripts/prepare-commit-message.js",
     "prepublishOnly": "npm i && npm run build",


### PR DESCRIPTION
I've discovered this because of #448. Since we now have `*.d.ts` file in `dist/`, after running `npm run build` and `npm run lint` I got:

```bash
$ npm run lint

> @sonarwhal/sonar@0.3.0 lint /Users/alrra/projects/sonar
> npm-run-all lint:*

> @sonarwhal/sonar@0.3.0 lint:js /Users/alrra/projects/sonar
> eslint --ext md --ext ts --ignore-pattern dist/* .

Cannot read property 'type' of null
TypeError: Cannot read property 'type' of null
    at Linter.onCodePathStart (/Users/alrra/projects/sonar/node_modules/eslint/lib/rules/array-callback-return.js:193:34)
    at emitTwo (events.js:130:20)
    at Linter.emit (events.js:213:7)
    at processCodePathToEnter (/Users/alrra/projects/sonar/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:357:30)
    at CodePathAnalyzer.enterNode (/Users/alrra/projects/sonar/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:599:9)
    at Traverser.enter (/Users/alrra/projects/sonar/node_modules/eslint/lib/linter.js:925:36)
    at Traverser.__execute (/Users/alrra/projects/sonar/node_modules/estraverse/estraverse.js:397:31)
    at Traverser.traverse (/Users/alrra/projects/sonar/node_modules/estraverse/estraverse.js:501:28)
    at Traverser.traverse (/Users/alrra/projects/sonar/node_modules/eslint/lib/util/traverser.js:31:22)
    at Linter.verify (/Users/alrra/projects/sonar/node_modules/eslint/lib/linter.js:922:28)
```