### PR TITLE
New: Ask about browserslist when generating config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -161,6 +161,16 @@
         "@types/node": "8.0.14"
       }
     },
+    "@types/inquirer": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.35.tgz",
+      "integrity": "sha512-/6WyyGROIw6qCmS8KmQtyt9Tj1OX7xIrGloAwMMOaNb3W/+QrrlL4Be4TDvLO4dlvw8gFrHfeXiWxS/k82jgEQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx": "4.1.1",
+        "@types/through": "0.0.29"
+      }
+    },
     "@types/is-my-json-valid": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/is-my-json-valid/-/is-my-json-valid-0.0.20.tgz",
@@ -244,6 +254,132 @@
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
       "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY="
     },
+    "@types/rx": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
+      "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4",
+        "@types/rx-lite": "4.0.4",
+        "@types/rx-lite-aggregates": "4.0.3",
+        "@types/rx-lite-async": "4.0.2",
+        "@types/rx-lite-backpressure": "4.0.3",
+        "@types/rx-lite-coincidence": "4.0.3",
+        "@types/rx-lite-experimental": "4.0.1",
+        "@types/rx-lite-joinpatterns": "4.0.1",
+        "@types/rx-lite-testing": "4.0.1",
+        "@types/rx-lite-time": "4.0.3",
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
+    },
+    "@types/rx-core": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
+      "integrity": "sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA=",
+      "dev": true
+    },
+    "@types/rx-core-binding": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
+      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3"
+      }
+    },
+    "@types/rx-lite": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.4.tgz",
+      "integrity": "sha1-cQ6/idCi1ZbCEEfZGxJCvO9Rwws=",
+      "dev": true,
+      "requires": {
+        "@types/rx-core": "4.0.3",
+        "@types/rx-core-binding": "4.0.4"
+      }
+    },
+    "@types/rx-lite-aggregates": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
+      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-async": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
+      "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-backpressure": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
+      "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-coincidence": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
+      "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-experimental": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
+      "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-joinpatterns": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
+      "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-testing": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
+      "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite-virtualtime": "4.0.3"
+      }
+    },
+    "@types/rx-lite-time": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
+      "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
+    "@types/rx-lite-virtualtime": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
+      "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
+      "dev": true,
+      "requires": {
+        "@types/rx-lite": "4.0.4"
+      }
+    },
     "@types/semver": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.4.0.tgz",
@@ -265,6 +401,15 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.3.3.tgz",
       "integrity": "sha512-bnoHhhCsx0p0yhLOywFg6T7Le37JjtnzLcWal6cuSPvIZUBzKRIsqM6E5OsKUIRVErCaBCghHIZmqtyGk5uXyA==",
       "dev": true
+    },
+    "@types/through": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.29.tgz",
+      "integrity": "sha512-9a7C5VHh+1BKblaYiq+7Tfc+EOmjMdZaD1MYtkQjSoxgB69tBjW98ry6SKsi4zEIWztLOMRuL87A3bdT/Fc/4w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "8.0.14"
+      }
     },
     "@types/tough-cookie": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/debug": "0.0.30",
     "@types/file-type": "5.2.1",
     "@types/iconv-lite": "0.0.1",
+    "@types/inquirer": "0.0.35",
     "@types/is-my-json-valid": "0.0.20",
     "@types/jsdom": "^11.0.0",
     "@types/json-stable-stringify": "^1.0.32",

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -80,7 +80,7 @@ const notifyNewVersion = (update: updateNotifier.UpdateInfo) => {
     notifier.notify({ message });
 };
 
-const confirmLaunchInit = () => {
+const confirmLaunchInit = (): inquirer.Answers => {
     debug(`Initiating launch init confirm.`);
 
     const question: Array<object> = [{
@@ -102,7 +102,7 @@ const loadOrCreateIfNotExits = async () => {
         config = Config.load(configPath);
     } catch (err) {
         // The config file doesn't exist, launch `init` if user permits.
-        const launchInit: { confirm: boolean } = await confirmLaunchInit();
+        const launchInit: inquirer.Answers = await confirmLaunchInit();
 
         if (launchInit.confirm) {
             await initSonarrc();

--- a/src/lib/cli/browserslist-generator.ts
+++ b/src/lib/cli/browserslist-generator.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Generates a valid browserslist config.
+ */
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+import * as inquirer from 'inquirer';
+import * as browserslist from 'browserslist';
+import * as logger from '../utils/logging';
+import { debug as d } from '../utils/debug';
+
+const debug: debug.IDebugger = d(__filename);
+
+export const generateBrowserslistConfig = (): Promise<Array<string>> => {
+    debug('Initiating browserslist config generator');
+
+    const addBrowsersListOptions: Array<inquirer.ChoiceType> = [
+        { name: 'Default (last 2 versions of each browser, and browsers with globaly usage over 1%, plus Firefox ESR)', value: 'default' },
+        { name: 'Custom (use browserslist format:  https://github.com/ai/browserslist#queries)', value: 'custom' }
+    ];
+
+    const browsersListQuestions: inquirer.Questions = [
+        {
+            choices: addBrowsersListOptions,
+            message: 'What browsers are you targeting?',
+            name: 'targetBy',
+            type: 'list'
+        },
+        {
+            message: 'Please enter the queries you want to specify (Use comma as the separator if you have more than one query):',
+            name: 'customQueries',
+            when: (answers) => {
+                return answers.targetBy === 'custom';
+            }
+        }
+    ];
+
+    const askAndValidate = async (): Promise<Array<string>> => {
+        const results: inquirer.Answers = await inquirer.prompt(browsersListQuestions);
+
+        if (results.targetBy === 'default') {
+            return [];
+        }
+
+        const customQueries: Array<string> = results.customQueries.split(',').map((query: string) => {
+            return query.trim();
+        });
+
+        try {
+            browserslist(customQueries);
+
+            return customQueries;
+        } catch (err) {
+            // The query format is invalid.
+            logger.log(`${err.message}.`);
+            logger.log('Please try again.');
+
+            return askAndValidate();
+        }
+    };
+
+    return askAndValidate();
+};

--- a/tests/lib/cli/browserlist-generator.ts
+++ b/tests/lib/cli/browserlist-generator.ts
@@ -1,0 +1,77 @@
+import * as proxyquire from 'proxyquire';
+import * as sinon from 'sinon';
+import test from 'ava';
+
+const inquirer = { prompt() { } };
+const logger = { log() { } };
+
+proxyquire('../../../src/lib/cli/browserslist-generator', {
+    '../utils/logging': logger,
+    inquirer
+});
+
+import { generateBrowserslistConfig } from '../../../src/lib/cli/browserslist-generator';
+
+const defaultOption = { targetBy: 'default' };
+const multipleQueries = {
+    customQueries: '> 1%, Last 2 versions',
+    targetBy: 'custom'
+};
+const invalidQueries = {
+    customQueries: 'invalid query',
+    targetBy: 'custom'
+};
+
+test.beforeEach((t) => {
+    t.context.sandbox = sinon.sandbox.create();
+});
+
+test.afterEach((t) => {
+    t.context.sandbox.restore();
+});
+
+test.serial('User selects to customize the queries, the format of the queries is wrong in the first trial', async (t) => {
+    const sandbox = t.context.sandbox;
+
+    sandbox.stub(inquirer, 'prompt')
+        .onFirstCall()
+        .resolves(invalidQueries)
+        .onSecondCall()
+        .resolves(multipleQueries);
+    sandbox.spy(logger, 'log');
+
+    const config = await generateBrowserslistConfig();
+    const log = logger.log as sinon.SinonSpy;
+
+    t.is(log.callCount, 2);
+    t.is(log.args[0][0], 'Unknown browser query `invalid query`.');
+    t.is(log.args[1][0], 'Please try again.');
+
+    t.is(config.length, 2);
+    t.is(config[0], '> 1%');
+    t.is(config[1], 'Last 2 versions');
+});
+
+test.serial('User selects to customize the queries, and has multile queries', async (t) => {
+    const sandbox = t.context.sandbox;
+
+    sandbox.stub(inquirer, 'prompt').resolves(multipleQueries);
+
+    const config = await generateBrowserslistConfig();
+
+    t.is(config.length, 2);
+    t.is(config[0], '> 1%');
+    t.is(config[1], 'Last 2 versions');
+});
+
+test.serial(`User selects the default option`, async (t) => {
+    const sandbox = t.context.sandbox;
+
+    sandbox.stub(inquirer, 'prompt').resolves(defaultOption);
+
+    const config = await generateBrowserslistConfig();
+
+    t.is(config.length, 0);
+
+    sandbox.restore();
+});


### PR DESCRIPTION
Fix #446 
I'm currently working on adding tests, but feedback on the options are welcome:

I checked out a few dependents of `browserslist` to see what queries are most often used. `last 2 versions` show up frequently, but a lot of them simply provide an interface to pass their users' queries to `browserslist`, which means they use `browserslist`'s default if not defined. Here in this PR, we have 4 options in the beginning:
* Default list from browserslist
* Last 2 versions of all browsers
* Add by percentage of usage statistics. (e.g., `>= 5%`, 5% by default)
* Add by specific browser type and version number range. (e.g., `IE 6-8`)

The users can define the value of `usage percentage`, `browser type` and the `version numbers`. Also the dialogue will be prompted in a recursive manner so if a user wants to add additional query he/she will be able to do so.
