### PR TITLE
Fix: Fix error in `onLoadingFailed`

### DIFF
--- a/src/lib/connectors/jsdom/jsdom.ts
+++ b/src/lib/connectors/jsdom/jsdom.ts
@@ -210,6 +210,7 @@ class JSDOMConnector implements IConnector {
 
             // TODO: Replace `null` with `resource` once it
             // can be converted to `JSDOMAsyncHTMLElement`.
+            // Event is also emitted when status code in response is not 200.
             await this._server.emitAsync('fetch::end', fetchEndEvent);
 
             return callback(null, resourceNetworkData.response.body.content);
@@ -368,6 +369,7 @@ class JSDOMConnector implements IConnector {
                 response: this._targetNetworkData.response
             };
 
+            // Event is also emitted when status code in response is not 200.
             await this._server.emitAsync('targetfetch::end', fetchEnd);
 
             jsdom.env({

--- a/src/lib/connectors/shared/remote-debugging-connector.ts
+++ b/src/lib/connectors/shared/remote-debugging-connector.ts
@@ -233,7 +233,7 @@ export class Connector implements IConnector {
         }
 
         if (params.type === 'Manifest') {
-            const { request: { url: resource } } = this._requests.get(params.requestId);
+            const { request: { url: resource } } = request;
             const event: IManifestFetchError = {
                 error: new Error(params.errorText),
                 resource
@@ -254,7 +254,7 @@ export class Connector implements IConnector {
 
         debug(`Error found:\n${JSON.stringify(params)}`);
         const element: AsyncHTMLElement = await this.getElementFromRequest(params.requestId);
-        const { request: { url: resource } } = this._requests.get(params.requestId);
+        const { request: { url: resource } } = request;
         const eventName: string = this._href === resource ? 'targetfetch::error' : 'fetch::error';
 
         const hops: Array<string> = this._redirects.calculate(resource);
@@ -382,6 +382,7 @@ export class Connector implements IConnector {
          * to avoid emitting duplidate events.
          */
         if (!this.rootFaviconRequestOrResponse(params)) {
+            /** Event is also emitted when status code in response is not 200. */
             await this._server.emitAsync(eventName, data);
         }
 


### PR DESCRIPTION
Fix #469

The reason that this issue happened is as below:

The page has many failed requests to https://betterment.report-uri.io/r/default/csp/reportOnly. Both `onResponseReceived` and `onLoadingFailed` were fired upon the failed requests. In the beginning, this request exists in `this._requests`, so  the check below in `onLoadingFailed` passes. But soon after this check the request is removed from `this._requests` in the `onResponseReceived` since it is running cocurrently. So later on in `onLoadingFailed`, the destructuring `const { request: { url: resource } } = this._requests.get(params.requestId)` fails, because at this stage, the request has already been removed from `this._requests` and `this._requests.get(params.requestId)` returns nothing.

The check in `onLoadingFailed` that gets bypassed:
https://github.com/sonarwhal/sonar/blob/0cc1f05e515755e6f25542c6c4d0362b48e3ba4e/src/lib/connectors/shared/remote-debugging-connector.ts#L216-L224

Solution:
Instead of retrieving request from `this._requests` every time, use the value previously saved in variable `request` for destructuring assignment. However, this means for a failed request, both `fetch::end` and ` fetch::error` might be emitted. I'm not sure if this is the intended behavior. Maybe we should consider adding conditions for emitting `fetch::end`  like only emit if the status is 200?