### PR TITLE
Fix: Remove `null` locations in the error message

### DIFF
--- a/src/lib/rule-context.ts
+++ b/src/lib/rule-context.ts
@@ -97,12 +97,8 @@ export class RuleContext {
             sourceCode = (await element.outerHTML()).replace(/[\t]/g, '    ');
         }
 
-        if (position === null) {
-            position = {
-                column: null,
-                line: null
-            };
-        }
+        // If location is undefined or equal to null, `position` will be set as `{ column: -1, line: -1 }` later in `sonar.report`.
+        // So pass the `location` on as it is.
 
         this.sonar.report(
             this.id,


### PR DESCRIPTION
Fix #478

The page loads some scripts multiple times, which results in the duplicate messages. It makes sense but looks like duplicate evaluation, should we add a filter similar to what we did to `jsdom`  in https://github.com/sonarwhal/sonar/pull/468?