### PR TITLE
Chore: Use compact html checker reports

### DIFF
--- a/docs/user-guide/rules/html-checker.md
+++ b/docs/user-guide/rules/html-checker.md
@@ -43,6 +43,19 @@ For explanation behind those requirements, please checkout:
 
 ## Can the rule be configured?
 
+By default only the first occurance of each error/warning is reported
+when validating the markup. However, you can configure the rule to view the
+complete list.
+
+The following configuration will enable the full-list view of errors/warnings
+reported by the HTML checker:
+
+```json
+"html-checker": ["error", {
+    "details": true
+}]
+```
+
 You can ignore certain error/warning by setting the `ignore` option
 for the `html-checker` rule. You can either pass in a string or an
 array that contains all the messages to be ignored.

--- a/tests/lib/rules/html-checker/tests.ts
+++ b/tests/lib/rules/html-checker/tests.ts
@@ -43,6 +43,17 @@ const defaultCheckerMessages = {
             extract: '-section"><h1>example<',
             hiliteStart: 10,
             hiliteLength: 4
+        },
+        {
+            type: 'info',
+            lastLine: 1,
+            lastColumn: 3000,
+            firstColumn: 2000,
+            subType: 'warning',
+            message: 'Consider using the “h1” element as a top-level heading only (all “h1” elements are treated as top-level headings by many screen readers and other tools)',
+            extract: '-section"><h1>example<',
+            hiliteStart: 8,
+            hiliteLength: 9
         }
     ]
 };
@@ -161,6 +172,42 @@ const testsForValidatorConfig: Array<IRuleTest> = [
     }
 ];
 
+const testsForDetailsConfig: Array<IRuleTest> = [
+    {
+        name: 'Configure to show complete list of errors/warnings',
+        serverUrl: exampleUrl,
+        before() {
+            htmlCheckerMock({ pass: true });
+        }
+    },
+    {
+        name: 'Reports warnings/errors if the HTML checker returns messages',
+        serverUrl: exampleUrl,
+        reports: [{
+            message: defaultCheckerMessages.messages[0].message,
+            position: {
+                column: defaultCheckerMessages.messages[0].firstColumn,
+                line: defaultCheckerMessages.messages[0].lastLine
+            }
+        }, {
+            message: defaultCheckerMessages.messages[1].message,
+            position: {
+                column: defaultCheckerMessages.messages[1].firstColumn,
+                line: defaultCheckerMessages.messages[1].lastLine
+            }
+        }, {
+            message: defaultCheckerMessages.messages[2].message,
+            position: {
+                column: defaultCheckerMessages.messages[2].firstColumn,
+                line: defaultCheckerMessages.messages[2].lastLine
+            }
+        }],
+        before() {
+            htmlCheckerMock({ error: true });
+        }
+    }
+];
+
 const testsForErrors: Array<IRuleTest> = [
     {
         name: 'Reports error when not able to get result from the HTML Checker',
@@ -183,6 +230,10 @@ ruleRunner.testRule(ruleName, testsForIgnoreArrayConfigs, {
 });
 ruleRunner.testRule(ruleName, testsForValidatorConfig, {
     ruleOptions: { validator: configValidator },
+    serial: true
+});
+ruleRunner.testRule(ruleName, testsForDetailsConfig, {
+    ruleOptions: { details: true },
     serial: true
 });
 


### PR DESCRIPTION
Fix #474

366 errors/warnings from `html-checker` are reduced to ~ 20:

![gmail-html-checker](https://user-images.githubusercontent.com/20218531/29947578-299839ce-8e5f-11e7-8f3b-30ae05a33045.PNG)
