### PR TITLE
Fix: Improve error messages for `highest-available-document-mode` rule 

### DIFF
--- a/src/lib/rules/highest-available-document-mode/highest-available-document-mode.ts
+++ b/src/lib/rules/highest-available-document-mode/highest-available-document-mode.ts
@@ -82,8 +82,11 @@ const rule: IRuleBuilder = {
 
             if (!requireMetaTag || suggestRemoval) {
                 if (XUACompatibleMetaTags.length !== 0) {
+
+                    const errorMessage = suggestRemoval ? 'Meta tag is not needed' : 'Meta tag usage is discouraged, use equivalent HTTP header';
+
                     for (const metaTag of XUACompatibleMetaTags) {
-                        await context.report(resource, metaTag, `Meta tag is not needed`);
+                        await context.report(resource, metaTag, errorMessage);
                     }
                 }
 

--- a/tests/lib/rules/highest-available-document-mode/tests.ts
+++ b/tests/lib/rules/highest-available-document-mode/tests.ts
@@ -43,7 +43,7 @@ const testsForHeaders: Array<IRuleTest> = [
     },
     {
         name: `HTML page is served with 'X-UA-Compatible' header and the meta tag`,
-        reports: [{ message: `Meta tag is not needed` }],
+        reports: [{ message: `Meta tag usage is discouraged, use equivalent HTTP header` }],
         serverConfig: {
             '/': {
                 content: generateHTMLPageWithMetaTag(),


### PR DESCRIPTION
Update error messages for the `highest-available-document-mode` rule in order to make it more clear why the removal of the meta tag is suggested.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref #477
Fix #477