### PR TITLE
Chore: Move `evaluate` to child process

### DIFF
--- a/src/lib/connectors/jsdom/evaluate-runner.ts
+++ b/src/lib/connectors/jsdom/evaluate-runner.ts
@@ -1,0 +1,47 @@
+import * as vm from 'vm';
+
+import * as jsdom from 'jsdom/lib/old-api';
+import * as jsdomutils from 'jsdom/lib/jsdom/living/generated/utils';
+
+const run = (data) => {
+    const { source } = data;
+    const result = {
+        error: null,
+        evaluate: 'result'
+    };
+    const url = process.argv[2];
+    const waitFor = process.argv[3];
+
+    jsdom.env({
+        done: (error, window) => {
+            if (error) {
+                result.error = error;
+
+                return process.send(result);
+            }
+
+            /* Even though `done()` is called after window.onload (so all resoruces and scripts executed),
+                      we might want to wait a few seconds if the site is lazy loading something. */
+            return setTimeout(async () => {
+                try {
+                    const script: vm.Script = new vm.Script(source);
+                    const evaluteResult = await script.runInContext(jsdomutils.implForWrapper(window.document)._global);
+
+                    result.evaluate = evaluteResult;
+                } catch (err) {
+                    result.error = err;
+                }
+
+                process.send(result);
+            }, waitFor);
+        },
+        features: {
+            FetchExternalResources: ['script', 'link', 'img'],
+            ProcessExternalResources: ['script'],
+            SkipExternalResources: false
+        },
+        url
+    });
+};
+
+process.on('message', run);

--- a/src/lib/rules/axe/axe.ts
+++ b/src/lib/rules/axe/axe.ts
@@ -11,7 +11,7 @@ import { AxeResults, Result as AxeResult, NodeResult as AxeNodeResult } from 'ax
 
 import { readFileAsync } from '../../utils/misc';
 import { debug as d } from '../../utils/debug';
-import { IAsyncHTMLElement, ITraverseEnd, IRule, IRuleBuilder, Severity } from '../../types'; // eslint-disable-line no-unused-vars
+import { IAsyncHTMLElement, IRule, IRuleBuilder, Severity, ITraverseEnd } from '../../types'; // eslint-disable-line no-unused-vars
 import { RuleContext } from '../../rule-context'; // eslint-disable-line no-unused-vars
 
 const debug = d(__filename);


### PR DESCRIPTION
* Move `evaluate` to its child process
* Start `evaluate` on `traverse::start`

This solves the stuck spinner issue.

Fix #485