### PR TITLE
Fix: Make apple-touch-icons work with any files

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -10,6 +10,7 @@
     "formatter": "stylish",
     "rulesTimeout": 120000,
     "rules": {
+        "apple-touch-icons": "warning",
         "axe": "warning",
         "content-type": "warning",
         "disown-opener": "warning",

--- a/src/lib/rules/apple-touch-icons/apple-touch-icons.ts
+++ b/src/lib/rules/apple-touch-icons/apple-touch-icons.ts
@@ -115,12 +115,30 @@ const rule: IRuleBuilder = {
 
             // - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-            // Note: Async version of `image-size` doesn't work if the
-            // input is a Buffer.
-            //
-            // https://github.com/image-size/image-size/tree/4c527ba608d742fbb29f6d9b3c77b831b069cbb2#asynchronous
+            let image;
 
-            const image = getImageData(response.body.rawContent);
+            // Notes:
+            //
+            //  * Async version of `image-size` doesn't work if the
+            //    input is a Buffer.
+            //
+            //    https://github.com/image-size/image-size/tree/4c527ba608d742fbb29f6d9b3c77b831b069cbb2#asynchronous
+            //
+            // * `image-size` will throw a `TypeError` error if it does
+            //    not understand the file type or the image is invalid
+            //    or corrupted.
+
+            try {
+                image = getImageData(response.body.rawContent);
+            } catch (e) {
+                if (e instanceof TypeError) {
+                    await context.report(resource, appleTouchIcon, `'${appleTouchIconHref}' is not a valid PNG`);
+                } else {
+                    debug(`'getImageData' failed for '${appleTouchIconURL}'`);
+                }
+
+                return;
+            }
 
             // Check if the image is a PNG.
 

--- a/tests/lib/rules/apple-touch-icons/tests.ts
+++ b/tests/lib/rules/apple-touch-icons/tests.ts
@@ -86,6 +86,14 @@ const tests: Array<IRuleTest> = [
         }
     },
     {
+        name: `'apple-touch-icon' is not an image`,
+        reports: [{ message: `'/apple-touch-icon.png' is not a valid PNG` }],
+        serverConfig: {
+            '/': generateHTMLPage(appleTouchIconLinkTag),
+            '/apple-touch-icon.png': generateHTMLPage()
+        }
+    },
+    {
         name: `'apple-touch-icon' is not 180x180px`,
         reports: [{ message: `'/apple-touch-icon.png' is not 180x180px` }],
         serverConfig: {


### PR DESCRIPTION
Make `apple-touch-icons` rule gracefully handle the cases when sites respond to the image request with something other then an image or with a invalid or corrupted image.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #515

<!--

Read our pull request guide:
https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

----

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [x] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
