### PR TITLE
Fix: Improve `connector` documentation

### DIFF
--- a/.sonarrc
+++ b/.sonarrc
@@ -2,9 +2,7 @@
     "connector": {
         "name": "chrome",
         "options": {
-            "waitFor": 1000,
-            "loadCompleteRetryInterval": 500,
-            "maxLoadWaitTime": 30000
+            "waitFor": 1000
         }
     },
     "formatter": "stylish",

--- a/docs/user-guide/connectors/index.md
+++ b/docs/user-guide/connectors/index.md
@@ -4,20 +4,16 @@ The current supported connectors are:
 
 * `jsdom`: Your website will be loaded using [`jsdom`][jsdom].
 * `chrome`: Your website will be loaded using Chrome and the Chrome
-  Debugging Protocol.
+  Debugging Protocol. This is one of the `remote-debugging-connector`s
 
-## chrome
+## Configuration
 
-The `chrome` connector uses the [Chrome Debugging Protocol][cdp] to
-communicate with the browser.
-
-### chrome configuration
-
-The following properties can be customized in your `.sonarrc` file, under the
-`options` property of the `connector`:
+The following properties can be customized in your `.sonarrc` file,
+under the `options` property of the `connector` for any of the
+officially supported ones:
 
 * `waitFor` time in milliseconds the connector will wait after the site is
-  ready before starting the DOM traversing. The default value is `5000`
+  ready before starting the DOM traversing. The default value is `1000`
   milliseconds.
 
 The following is the default configuration:
@@ -25,11 +21,47 @@ The following is the default configuration:
 ```json
 {
     "connector": {
-        "name": "chrome",
+        "name": "chrome|jsdom",
         "options": {
-            "waitFor": 5000
+            "waitFor": 1000
         }
     }
+}
+```
+
+### jsdom configuration
+
+`jsdom` allows you to configure the following:
+
+* `headers`: the headers used to fetch the resources. By default they are:
+
+```json
+ {
+    "Accept-Language": "en-US,en;q=0.8,es;q=0.6,fr;q=0.4",
+    "Cache-Control": "no-cache",
+    "DNT": 1,
+    "Pragma": "no-cache",
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36"
+}
+```
+
+### remote-debugging-connector configuration
+
+There are some `connector`s built on top of the [chrome debugging
+protocol][cdp]. `chrome` is one of these `connector`s.
+
+The set of settings specific for them are:
+
+* `useTabUrl`: Indicates if the browser should navigate first to a
+  given page before going to the final target. `false` by default.
+* `tabUrl`: The url to visit before the final target in case
+  `useTabUrl` is `true`. `https://empty.sonarwhal.com/` is the
+  default value.
+
+```json
+{
+    "tabUrl": "https://empty.sonarwhal.com/",
+    "useTabUrl": false
 }
 ```
 
@@ -40,7 +72,7 @@ Connectors are expected to implement at least some basic functionality
 but expose more events or have some extra functionality. The following
 document details the known differences among the official connectors.
 
-### JSDOM
+### jsdom
 
 * It will not send the events for:
 

--- a/src/lib/connectors/shared/remote-debugging-connector.ts
+++ b/src/lib/connectors/shared/remote-debugging-connector.ts
@@ -75,13 +75,11 @@ export class Connector implements IConnector {
 
     public constructor(server: Sonar, config: object, launcher: ILauncher) {
         const defaultOptions = {
-            loadCompleteRetryInterval: 250,
-            maxLoadWaitTime: 30000,
             // tabUrl is a empty html site used to avoid edge diagnostics adapter to receive unexpeted onLoadEventFired
             // and onRequestWillBeSent events from the default url opened when you create a new tab in Edge.
             tabUrl: 'https://empty.sonarwhal.com/',
             useTabUrl: false,
-            waitFor: 5000
+            waitFor: 1000
         };
 
         this._server = server;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,8 +22,6 @@ export interface IRuleConfigList {
 
 export interface IConnectorOptionsConfig {
     waitFor?: number;
-    loadCompleteRetryInterval?: number;
-    maxLoadWaitTime?: number;
 }
 
 export interface IConnectorConfig {


### PR DESCRIPTION
* Explain the common properties to all `connector`s
* Explain the specific properties for each one
* Remove `loadCompleteRetryInterval`, and `maxLoadWaitTime` from the
  code as they weren't used any more
* Normalize `waitFor` to `1000` for all `connector`s

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #500