### PR TITLE
Fix: Add `tests/helpers` to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
   "files": [
     ".sonarrc",
     "dist/src",
+    "dist/tests/helpers",
     "docs",
     "npm-shrinkwrap.json"
   ],


### PR DESCRIPTION
This will enable developers to use the same infrastructure we do to
test their custom rules.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: https://github.com/sonarwhal/sonar/issues/528#issuecomment-331321328