### PR TITLE
Chore: Add new location to load resources

### DIFF
--- a/src/lib/utils/resource-loader.ts
+++ b/src/lib/utils/resource-loader.ts
@@ -102,7 +102,9 @@ export const loadResource = (name: string, type: string) => {
     const sources: Array<string> = [
         path.normalize(`${PROJECT_ROOT}/dist/src/lib/${type}s/${name}/${name}.js`),
         `@sonarwhal/${name}`,
-        `sonarwhal-${name}`
+        `sonarwhal-${name}`,
+        // This is needed to test an external rule using the official template
+        path.normalize(`${process.cwd()}/dist/src/${name}.js`)
     ];
 
     let resource: any;

--- a/tests/lib/utils/resource-loader.ts
+++ b/tests/lib/utils/resource-loader.ts
@@ -26,14 +26,16 @@ test('loadResource looks for resources in the right order (core > @sonarwhal > s
     tryToLoadFromStub.onFirstCall().returns(null);
     tryToLoadFromStub.onSecondCall().returns(null);
     tryToLoadFromStub.onThirdCall().returns(null);
+    tryToLoadFromStub.onCall(3).returns(null);
 
     t.throws(() => {
         resourceLoader.loadResource(resourceName, resourceType);
     });
-    t.true(tryToLoadFromStub.calledThrice, 'tryToLoadFromStub is called thrice');
+    t.true(tryToLoadFromStub.callCount === 4, 'tryToLoadFromStub is called four times');
     t.true((tryToLoadFromStub.firstCall.args[0] as string).endsWith(path.normalize(`/dist/src/lib/${resourceType}s/${resourceName}/${resourceName}.js`)), 'Tries to load core first');
     t.true((tryToLoadFromStub.secondCall.args[0] as string).endsWith(`@sonarwhal/${resourceName}`), 'Tries to load scoped package second');
     t.true((tryToLoadFromStub.thirdCall.args[0] as string).endsWith(`sonarwhal-${resourceName}`), 'Tries to load prefixed package third');
+    t.true((tryToLoadFromStub.lastCall.args[0] as string).endsWith(path.normalize(`/dist/src/${resourceName}.js`)), 'Tries to load local testing fourth');
 
     tryToLoadFromStub.restore();
 });


### PR DESCRIPTION
The new location in `resource-loader` enables testing in the
[official rule template][template] using the same infrastructure
than the core rules.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref https://github.com/sonarwhal/sonar/issues/528

[template]: https://github.com/sonarwhal/sonarwhal-rule-template