### PR TITLE
Fix: Create new rule only in `sonar`'s root folder

### DIFF
--- a/src/lib/cli/rules/common.ts
+++ b/src/lib/cli/rules/common.ts
@@ -6,7 +6,8 @@ export const ruleScriptDir = 'src/lib/rules';
 export const ruleDocDir = 'docs/user-guide/rules';
 export const ruleTestDir = 'tests/lib/rules';
 export const ruleDistScriptDir = `dist/${ruleScriptDir}`;
-export const dir = packageRoot();
+export const packageDir = packageRoot();
+export const processDir = process.cwd();
 
 /** Check if a rule exists. */
 export const ruleExists = (ruleName: string, currentRules: Array<string>): boolean => {

--- a/src/lib/cli/rules/create-core-rule.ts
+++ b/src/lib/cli/rules/create-core-rule.ts
@@ -12,7 +12,7 @@ import { debug as d } from '../../utils/debug';
 import * as logger from '../../utils/logging';
 import * as resourceLoader from '../../utils/resource-loader';
 import {
-    dir, normalize,
+    processDir, packageDir, normalize,
     NewRule,
     ruleDocDir, ruleExists, ruleScriptDir, ruleTemplateDir, ruleTestDir
 } from './common';
@@ -80,13 +80,13 @@ const loadRuleContent = (rule: NewRule, type: string): Promise<string> => {
 const generateRuleContent = async (rule: NewRule): Promise<void> => {
     const entries = [
         {
-            file: path.join(dir, ruleScriptDir, rule.name, `${rule.name}.ts`),
+            file: path.join(packageDir, ruleScriptDir, rule.name, `${rule.name}.ts`),
             type: 'script'
         }, {
-            file: path.join(dir, ruleDocDir, `${rule.name}.md`),
+            file: path.join(packageDir, ruleDocDir, `${rule.name}.md`),
             type: 'doc'
         }, {
-            file: path.join(dir, ruleTestDir, rule.name, 'tests.ts'),
+            file: path.join(packageDir, ruleTestDir, rule.name, 'tests.ts'),
             type: 'test'
         }];
 
@@ -101,7 +101,7 @@ const generateRuleContent = async (rule: NewRule): Promise<void> => {
 
 /** Adds a new rule to the index page. */
 const updateRuleIndex = async (rule: NewRule): Promise<void> => {
-    const indexPath = path.join(dir, ruleDocDir, 'index.md');
+    const indexPath = path.join(packageDir, ruleDocDir, 'index.md');
     let text;
 
     try {
@@ -200,6 +200,10 @@ const questions = [
 /** Generates a new core rule based on user input. */
 export const newRule = async (actions: CLIOptions): Promise<boolean> => {
     if (!actions.newRule) {
+        return false;
+    }
+
+    if (packageDir !== processDir) {
         return false;
     }
 

--- a/src/lib/cli/rules/delete-core-rule.ts
+++ b/src/lib/cli/rules/delete-core-rule.ts
@@ -7,7 +7,7 @@ import { debug as d } from '../../utils/debug';
 import * as inquirer from 'inquirer';
 import * as rimraf from 'rimraf';
 
-import { dir, normalize, ruleDistScriptDir, ruleDocDir, ruleExists, ruleScriptDir, ruleTestDir } from './common';
+import { packageDir, normalize, ruleDistScriptDir, ruleDocDir, ruleExists, ruleScriptDir, ruleTestDir } from './common';
 import * as logger from '../../utils/logging';
 import * as resourceLoader from '../../utils/resource-loader';
 
@@ -15,7 +15,7 @@ const debug = d(__filename);
 
 /** Removes a given rule from the index page. */
 const removeFromRuleIndex = async (ruleName: string): Promise<void> => {
-    const indexPath = path.join(dir, ruleDocDir, 'index.md');
+    const indexPath = path.join(packageDir, ruleDocDir, 'index.md');
     let text;
 
     try {
@@ -54,10 +54,10 @@ export const deleteRule = async (actions: CLIOptions): Promise<boolean> => {
     const currentRules: Array<string> = resourceLoader.getCoreRules();
 
     const normalizedName = normalize(results.name, '-');
-    const scriptPath = path.join(dir, ruleScriptDir, normalizedName);
-    const docPath = path.join(dir, ruleDocDir, `${normalizedName}.md`);
-    const testPath = path.join(dir, ruleTestDir, normalizedName);
-    const distScriptPath = path.join(dir, ruleDistScriptDir, normalizedName);
+    const scriptPath = path.join(packageDir, ruleScriptDir, normalizedName);
+    const docPath = path.join(packageDir, ruleDocDir, `${normalizedName}.md`);
+    const testPath = path.join(packageDir, ruleTestDir, normalizedName);
+    const distScriptPath = path.join(packageDir, ruleDistScriptDir, normalizedName);
 
     if (!ruleExists(normalizedName, currentRules)) {
         throw new Error(`This rule doesn't exist!`);


### PR DESCRIPTION
Fix #527