### PR TITLE
Chore: Add support for Windows builds via appveyor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sonar
 
 [![Build Status](https://travis-ci.org/sonarwhal/sonar.svg?branch=master)](https://travis-ci.org/sonarwhal/sonar)
+[![Build status](https://ci.appveyor.com/api/projects/status/8qq9qtp4b2af5ili/branch/master?svg=true)](https://ci.appveyor.com/project/NellieTheNarwhal/sonar/branch/master)
 [![Greenkeeper badge](https://badges.greenkeeper.io/sonarwhal/sonar.svg?ts=1493307106027)](https://greenkeeper.io/)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sonarwhal/Lobby)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  nodejs_version: Stable
+
+# Install scripts. (runs after repo cloning)
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  - node --version
+  - npm --version
+  - npm install
+  - choco install googlechrome
+
+# Post-install test scripts.
+test_script:
+  - npm test
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
Fix #184

Installation and test triggering seems to be [working now](https://ci.appveyor.com/project/NellieTheNarwhal/sonar/build/1.0.7)