### PR TITLE
Fix: Make tests more reliable and faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
     "babel": {
       "presets": []
     },
-    "concurrency": 5,
     "failFast": false,
     "files": [
       "dist/tests/**/*.js"

--- a/src/lib/rules/html-checker/html-checker.ts
+++ b/src/lib/rules/html-checker/html-checker.ts
@@ -89,10 +89,7 @@ const rule: IRuleBuilder = {
                when testing the rule and `import` doesn't work here. */
             const htmlChecker = require('html-validator');
 
-            /* Property `rawContent` can contain the information with
-             * different encodings depending on the connector we are using on sonar
-             * i.e. In Chrome it is utf8 but in Edge it is base64 */
-            scanOptions.data = response.body.rawContent.toString();
+            scanOptions.data = response.body.content;
             htmlCheckerPromise = scanOptions.data ? htmlChecker(scanOptions) : Promise.resolve({messages: []});
         };
 

--- a/tests/lib/rules/html-checker/tests.ts
+++ b/tests/lib/rules/html-checker/tests.ts
@@ -7,7 +7,7 @@ import * as ruleRunner from '../../../helpers/rule-runner';
 import { getRuleName } from '../../../../src/lib/utils/rule-helpers';
 
 const ruleName = getRuleName(__dirname);
-const exampleUrl = 'https://example.com/';
+const exampleUrl = 'https://empty.sonarwhal.com/';
 const validatorError = 'error';
 const defaultValidator = 'https://validator.w3.org/nu/';
 const configValidator = 'https://html5.validator.nu';

--- a/tests/lib/rules/strict-transport-security/tests.ts
+++ b/tests/lib/rules/strict-transport-security/tests.ts
@@ -24,8 +24,8 @@ const requestJSONAsyncMock = (responseObject) => {
         isDataURI() {
             return false;
         },
-        normalizeString(string) {
-            return string.toLowerCase();
+        normalizeString(str = '') {
+            return str.toLowerCase();
         },
         requestJSONAsync: (uri) => {
             let response;
@@ -84,7 +84,10 @@ const statusServiceError = `Error with getting preload status for https://localh
 const preloadableServiceError = `Error with getting preload eligibility for https://localhost/.`;
 
 // override favicon headers so that it doesn't report in chrome
-const faviconHeaderMaxAgeOnly = { '/favicon.ico': { headers: { [stsHeader]: `max-age=${OkayMaxAge + 100}` } } };
+const faviconHeaderMaxAgeOnly = {
+    '/': { content: generateHTMLPage() },
+    '/favicon.ico': { headers: { [stsHeader]: `max-age=${OkayMaxAge + 100}` } }
+};
 
 const generateHTMLPageData = (content: string) => {
     return {


### PR DESCRIPTION
* Remove `concurrency` from `package.json` and let `ava` decide how
  many should be run depending on the CPU
* Pick random port for `test-server` so it doesn't have to look for an
  available one as many times as before
* Fix issue with `static-transport-protocol` where the response could
  be empty and thus producing an exception
* Change test server for `html-checker` and how the html text is
  accessed

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #502