### PR TITLE
Fix: Make `meta-viewport` rule work with `viewport-fit` property

### DIFF
--- a/docs/user-guide/rules/meta-viewport.md
+++ b/docs/user-guide/rules/meta-viewport.md
@@ -193,7 +193,7 @@ If versions of Safari for iOS &lt; 9 are targeted:
     <head>
         <meta charset="utf-8">
         <title>example</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no, viewport-fit=cover">
         ...
     </head>
     <body>...</body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6081,9 +6081,9 @@
       "dev": true
     },
     "metaviewport-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.1.0.tgz",
-      "integrity": "sha1-l/pn6ku/ZA9P1ZAQ+I8QzqfVrMw="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
+      "integrity": "sha1-U1w84cz2IjpQJf3cahw2UF9+fbE="
     },
     "methods": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lockfile": "^1.0.3",
     "lodash": "^4.17.4",
     "log-symbols": "^2.1.0",
-    "metaviewport-parser": "^0.1.0",
+    "metaviewport-parser": "^0.2.0",
     "mime-db": "^1.30.0",
     "mkdirp": "^0.5.1",
     "node-ssllabs": "^0.5.0",

--- a/tests/lib/rules/meta-viewport/tests.ts
+++ b/tests/lib/rules/meta-viewport/tests.ts
@@ -64,6 +64,10 @@ const testsForDefaults: Array<IRuleTest> = [
         serverConfig: generateHTMLPage(generateMegaViewport())
     },
     {
+        name: `'viewport' meta tag has correct value with additional valid and allowed properties`,
+        serverConfig: generateHTMLPage('<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"')
+    },
+    {
         name: `Multiple meta 'viewport' tags are specified`,
         reports: [{ message: 'A viewport meta tag was already specified' }],
         serverConfig: generateHTMLPage(`${generateMegaViewport()}${generateMegaViewport()}`)


### PR DESCRIPTION
From https://webkit.org/blog/7929/designing-websites-for-iphone-x/

> The first new feature is an extension to the existing viewport meta tag called `viewport-fit`, which provides control over the insetting behavior. `viewport-fit` is available in iOS 11.
>
> The default value of `viewport-fit` is `auto`, which results in the automatic insetting behavior  seen above. In order to disable that behavior and cause the page to lay out to the full size of the screen, you can set `viewport-fit` to `cover`. After doing so, our viewport meta tag now looks like this:
>
> `<meta name='viewport' content='initial-scale=1, viewport-fit=cover'>`

(See also: https://www.w3.org/TR/css-round-display-1/#viewport-fit-descriptor)

Using that `viewport-fit` property currently generates an error because it needs to be added to `metaviewport-parser` (see: https://github.com/dontcallmedom/metaviewport-parser/issues/5).

---

Related: In a discussion with @molant  we agreed that the `meta-viewport` rule should not enforce the usage of  the `viewport-fit` property, as blindly using it [without any other adjustments](https://webkit.org/blog/7929/designing-websites-for-iphone-x/) can potentially create a bad user experience (i.e. part of the website may be obstructed by the sensor housing).