### PR TITLE
Fix: Update new version notifications handling

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -25,18 +25,25 @@ import { loadJSONFile } from './utils/misc';
 import { options } from './cli/options';
 import { cliActions } from './cli/actions';
 
-const pkg = loadJSONFile(path.join(__dirname, '../../../package.json'));
-// Fetch and persist comparison result in the background.
-// Check interval is set as one day by default.
-// To test immediately, set `updateCheckInterval` to 0 and pass it in as a param to `updateNotifier`.
-// Comparison result is loaded on the FIRST initiation, but users won't be notified until the SECOND time it runs.
-// Reference:https://github.com/yeoman/update-notifier#how
-const notifier = updateNotifier({
-    pkg,
-    updateCheckInterval: 1000 * 60 * 60 * 1 // One hour.
-});
+/** Notify user if the current version of sonar is not up to date. */
+const notifyIfNeeded = () => {
+    const pkg = loadJSONFile(path.join(__dirname, '../../../package.json'));
+    // Fetch and persist comparison result in the background.
+    // Check interval is set as one day by default.
+    // To test immediately, set `updateCheckInterval` to 0 and pass it in as a param to `updateNotifier`.
+    // Comparison result is loaded on the FIRST initiation, but users won't be notified until the SECOND time it runs.
+    // Reference:https://github.com/yeoman/update-notifier#how
+    const notifier = updateNotifier({
+        pkg,
+        updateCheckInterval: 1000 * 60 * 60 * 1 // One hour.
+    });
 
-const notifyNewVersion = (update: updateNotifier.UpdateInfo) => {
+    const update = notifier.update;
+
+    if (!update || update.latest === pkg.version) {
+        return;
+    }
+
     const changelogUrl: string = `https://sonarwhal.com/about/changelog.html`;
     // No indentation due to the use of `\` to avoid new line.
     // https://stackoverflow.com/a/35428171
@@ -52,17 +59,10 @@ const notifyNewVersion = (update: updateNotifier.UpdateInfo) => {
 
 /** Executes the CLI based on an array of arguments that is passed in. */
 export const execute = async (args: string | Array<string> | Object): Promise<number> => {
-
     const currentOptions: CLIOptions = options.parse(args);
-
-    // Notify user if the current version of sonar is not up to date.
-    const update: updateNotifier.UpdateInfo = notifier.update;
-
-    if (update) {
-        notifyNewVersion(update);
-    }
-
     let handled = false;
+
+    notifyIfNeeded();
 
     while (cliActions.length > 0 && !handled) {
         const action = cliActions.shift();


### PR DESCRIPTION
Add extra check to make sure the version reported by `update-notifier`
and the current one is different before prompting the user to update.

- - - - - - - - - - - - - - - - - - - -

Fix #507
