### PR TITLE
Fix: Generate correctly `.sonarrc` if not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "lint:js": "eslint --report-unused-disable-directives --ext md --ext ts --ignore-pattern dist .",
     "lint:md": "markdownlint docs",
     "preparecommitmsg": "node scripts/prepare-commit-message.js",
-    "release": "npm i && npm run build && node dist/scripts/release.js",
+    "release": "npm i && npm run test && node dist/scripts/release.js",
     "site": "node dist/src/bin/sonar",
     "test": "npm run lint && npm run commitmsg && npm run build && nyc ava",
     "test-on-travis": "npm run lint && npm run commitmsg && npm run build && nyc ava \"dist/tests/**/*.js\" --concurrency=2 --timeout=2m",

--- a/src/lib/cli/analyze.ts
+++ b/src/lib/cli/analyze.ts
@@ -29,14 +29,14 @@ const confirmLaunchInit = (): inquirer.Answers => {
     return inquirer.prompt(question);
 };
 
-const askUserToCreateConfig = async (actions: CLIOptions) => {
+const askUserToCreateConfig = async () => {
     const launchInit: inquirer.Answers = await confirmLaunchInit();
 
     if (!launchInit.confirm) {
         return false;
     }
 
-    await initSonarrc(actions);
+    await initSonarrc({init: true} as CLIOptions);
     logger.log(`Configuration file .sonarrc was created.`);
 
     return true;
@@ -51,7 +51,7 @@ const tryToLoadConfig = async (actions: CLIOptions) => {
         config = Config.load(configPath);
     } catch (e) {
         logger.log(`Couldn't load a valid configuration file in ${configPath}.`);
-        const created = await askUserToCreateConfig(actions);
+        const created = await askUserToCreateConfig();
 
         if (created) {
             config = await tryToLoadConfig(actions);

--- a/tests/lib/cli/analyze.ts
+++ b/tests/lib/cli/analyze.ts
@@ -105,6 +105,7 @@ test.serial('If config file does not exist, it should create a configuration fil
     t.true(t.context.inquirer.prompt.calledOnce);
     t.is(t.context.inquirer.prompt.args[0][0][0].name, 'confirm');
     t.true(t.context.generator.initSonarrc.calledOnce);
+    t.deepEqual(t.context.generator.initSonarrc.firstCall.args[0], { init: true });
 });
 
 test.serial('If config file does not exist and user refuses to create a configuration file, it should exit with code 1', async (t) => {


### PR DESCRIPTION
Fix #562