### PR TITLE
Fix: Removing shebangs from top of sonar.js

### DIFF
--- a/src/bin/sonar.ts
+++ b/src/bin/sonar.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * @fileoverview Main CLI that is run via the sonar command. Based on ESLint.
  */


### PR DESCRIPTION
`#!/usr/bin/env node` was causing sonar to throw `env: node\r: No such file or directory` from the command line on my Mac.

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Ref https://github.com/sonarwhal/sonar/issues/564
Fix #564
Close #564

<!--

Read our pull request guide:
https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
