### PR TITLE
Build: Make TypeScript enforce `LF` newlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "ava": "ava",
     "build": "npm run clean && npm-run-all build:*",
     "build:assets": "cpx \"./{scripts,src,tests}/**/{!(*.ts),.!(ts)}\" dist",
-    "build:ts": "tsc --outDir dist",
+    "build:ts": "tsc --outDir dist --newLine lf",
     "clean": "rimraf dist",
     "commitmsg": "node scripts/check-commit-message.js",
     "lint": "npm-run-all lint:*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
             "esnext.asynciterable",
             "dom",
             "dom.iterable"
-        ]
+        ],
+        "newLine": "lf"
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

From https://www.typescriptlang.org/docs/handbook/compiler-options.html:

> --newLine: Use the specified end of line sequence to be used when emitting files: 'crlf' (windows) or 'lf' (unix). "

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Fix #564 

@molant Please test this, and confirm it works! Thanks!