### PR TITLE
Docs: In .sonarrc, ignoredUrls must be an object

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -170,13 +170,10 @@ completely one (like a third party analytics, ads, etc.). To achieve
 this you need to add the `ignoredUrls` property to your `.sonarrc` file:
 
 ```json
-"ignoredUrls": [{
-    "domain": ".*\\.domain1\\.com/.*",
-    "rules": ["*"]
-}, {
-    "domain": "www.domain2.net",
-    "rules": ["disallowed-headers"]
-}]
+"ignoredUrls": {
+    ".*\\.domain1\\.com/.*": ["*"],
+    "www.domain2.net": ["disallowed-headers"]
+}
 ```
 
 Properties can be:


### PR DESCRIPTION
According to the behavior of the command line app, `ignoredUrls` must be an object where the keys are the domains and the values are the rules.

<!--

Read our pull request guide:
https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [x] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [x] Followed the [commit message guidelines](https://sonarwhal.com/docs/developer-guide/contributing/pull-requests.html#commitmessages)
