### PR TITLE
Fix: Debugging Protocol Connector improvements

### DIFF
--- a/src/lib/connectors/chrome/chrome-launcher.ts
+++ b/src/lib/connectors/chrome/chrome-launcher.ts
@@ -115,6 +115,7 @@ export class CDPLauncher extends Launcher {
 
             const chrome: chromeLauncher.LaunchedChrome = await chromeLauncher.launch({
                 chromeFlags,
+                logLevel: debug.enabled ? 'verbose' : 'silent',
                 startingUrl: url
             });
 

--- a/src/lib/connectors/debugging-protocol-common/debugging-protocol-connector.ts
+++ b/src/lib/connectors/debugging-protocol-common/debugging-protocol-connector.ts
@@ -792,8 +792,6 @@ export class Connector implements IConnector {
                 debug('Error connecting to browser');
                 debug(e);
 
-                await this._server.emitAsync('scan::end', event);
-
                 callback(e);
 
                 return;


### PR DESCRIPTION
* Add `verbose` mode to `chrome-launcher` when in `debug` mode
* Not emit `scan::end` if there's been a problem connecting to the
  browser in `debugging-protocol-connector`

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

Ref: #603

<!--

Read our pull request guide:
https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [X] Signed the [Contributor License Agreement](https://cla.js.foundation/sonarwhal/sonar)
- [X] Followed the [commit message guidelines](https://sonarwhal.com/docs/contributor-guide/contributing/pull-requests/#commitmessages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relavant issue number(s).

Thank you for taking the time to open this PR!

-->
